### PR TITLE
feat: Implement session and leaderboard endpoints with refactoring

### DIFF
--- a/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
@@ -40,22 +40,14 @@ class BiometricWebSocketController(
 
     private val log = LoggerFactory.getLogger(javaClass)
 
-    @MessageMapping("/treino/dados")
+    @MessageMapping("/train/data")
     fun receiveBiometricData(message: BiometricDataMessage) {
         val start = System.currentTimeMillis()
 
-        // 1. Salva estado biométrico atual do usuário no Redis HASH (HMSET)
-        //    Key: session:{sessionId}:user:{userId}
         sessionRedisService.saveUserState(message.sessionId, message.userId, message)
-
-        // 2. Atualiza distância do usuário no leaderboard ZSET (ZADD)
-        //    O score (distância) é sempre substituído, não acumulado — ZADD é idempotente
         leaderboardRedisService.updateUserDistance(message.sessionId, message.userId, message.accumulatedDistance)
 
-        // 3. Busca a posição atual do usuário no ranking (ZREVRANK — 0-based → +1)
         val userRank = (leaderboardRedisService.getUserRank(message.sessionId, message.userId) ?: 0L) + 1
-
-        // 4. Busca os top-10 do leaderboard (ZREVRANGE WITHSCORES)
         val entries = leaderboardRedisService.getTopEntries(message.sessionId, 10)
             ?.mapIndexed { index, tuple ->
                 LeaderboardEntryDto(
@@ -65,18 +57,14 @@ class BiometricWebSocketController(
                 )
             } ?: emptyList()
 
-        // 5. Calcula posição virtual da Horda (cálculo local, sem I/O)
-        //    startEpoch e hordePace foram gravados no Redis ao iniciar a sessão
         val startEpoch = leaderboardRedisService.getSessionStartEpoch(message.sessionId)
         val hordePace = leaderboardRedisService.getHordePace(message.sessionId)
         val hordeVirtualDistance = if (startEpoch != null && hordePace != null && hordePace > 0) {
             hordePositionService.calculateVirtualPosition(startEpoch, hordePace)
         } else {
-            null // Sessão sem Horda (treino livre)
+            null
         }
 
-        // 6. Broadcast do leaderboard atualizado para todos os inscritos na sessão
-        //    O app React Native recebe isso e atualiza a UI da corrida em tempo real
         val response = LeaderboardResponse(
             sessionId = message.sessionId,
             userRank = userRank.toInt(),

--- a/src/main/kotlin/br/inatel/tcc/controller/TrainSessionController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/TrainSessionController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 class TrainSessionController(
     private val trainSessionService: TrainSessionService
 ) {
-    @PostMapping("/iniciar")
+    @PostMapping("/start")
     fun startSession(
         @RequestBody request: StartSessionRequest,
         authentication: Authentication
@@ -26,7 +26,7 @@ class TrainSessionController(
         return ResponseEntity.status(HttpStatus.CREATED).body(response)
     }
 
-    @PostMapping("/{sessionId}/encerrar")
+    @PostMapping("/{sessionId}/finish")
     fun endSession(
         @PathVariable sessionId: String,
         authentication: Authentication

--- a/src/main/kotlin/br/inatel/tcc/controller/TrainSessionController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/TrainSessionController.kt
@@ -1,11 +1,14 @@
 package br.inatel.tcc.controller
 
+import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.dto.StartSessionResponse
+import br.inatel.tcc.model.TrainSession
 import br.inatel.tcc.service.TrainSessionService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody

--- a/src/main/kotlin/br/inatel/tcc/controller/TrainSessionController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/TrainSessionController.kt
@@ -12,34 +12,11 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-/**
- * Gerencia o ciclo de vida REST de uma sessão de treino.
- *
- * POST /sessions/iniciar   → cria sessão no PostgreSQL + inicializa Redis
- * POST /sessions/{id}/encerrar → lê leaderboard do Redis + persiste no PostgreSQL
- *
- * Esses endpoints são protegidos por JWT (Bearer token no Authorization header).
- * O WebSocket em /ws é separado e não passa por esses endpoints.
- *
- * TODO [FASE 2 - GET SESSIONS]: Adicionar GET /sessions/{id}/leaderboard para
- *   consulta do ranking atual sem precisar estar conectado via WebSocket
- *   (útil para o app recuperar estado após reconexão).
- *
- * TODO [FASE 3 - HISTÓRICO]: Adicionar GET /sessions?userId={id} para listar
- *   o histórico de sessões do usuário com resultados.
- *   Referência: TrainSessionRepository.findByUserId()
- */
 @RestController
 @RequestMapping("/sessions")
 class TrainSessionController(
     private val trainSessionService: TrainSessionService
 ) {
-
-    /**
-     * Inicia uma nova sessão de treino.
-     * Cria o registro no PostgreSQL e inicializa os keys Redis da sessão.
-     * Retorna o sessionId que o app React Native deve incluir em cada mensagem WebSocket.
-     */
     @PostMapping("/iniciar")
     fun startSession(
         @RequestBody request: StartSessionRequest,
@@ -49,10 +26,6 @@ class TrainSessionController(
         return ResponseEntity.status(HttpStatus.CREATED).body(response)
     }
 
-    /**
-     * Encerra a sessão: lê ranking final do Redis, persiste no PostgreSQL e
-     * reduz TTL dos keys Redis para 1h.
-     */
     @PostMapping("/{sessionId}/encerrar")
     fun endSession(
         @PathVariable sessionId: String,
@@ -60,5 +33,23 @@ class TrainSessionController(
     ): ResponseEntity<Void> {
         trainSessionService.endSession(sessionId)
         return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/{sessionId}/leaderboard")
+    fun getLeaderboard(
+        @PathVariable sessionId: String,
+        authentication: Authentication
+    ): ResponseEntity<List<LeaderboardEntryDto>> {
+        val leaderboard = trainSessionService.getLeaderboard(sessionId)
+        return ResponseEntity.ok(leaderboard)
+    }
+
+    @GetMapping("/{sessionId}")
+    fun getSession(
+        @PathVariable sessionId: String,
+        authentication: Authentication
+    ): ResponseEntity<TrainSession> {
+        val session = trainSessionService.getSession(sessionId)
+        return ResponseEntity.ok(session)
     }
 }

--- a/src/main/kotlin/br/inatel/tcc/controller/TrainSessionController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/TrainSessionController.kt
@@ -3,7 +3,7 @@ package br.inatel.tcc.controller
 import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.dto.StartSessionResponse
-import br.inatel.tcc.model.TrainSession
+import br.inatel.tcc.domain.trainsession.TrainSession
 import br.inatel.tcc.service.TrainSessionService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
@@ -7,6 +7,7 @@ import br.inatel.tcc.domain.trainsession.TrainSessionRepository
 import br.inatel.tcc.domain.trainsession.TrainType
 import br.inatel.tcc.domain.horde.HordeRepository
 import br.inatel.tcc.domain.user.UserRepository
+import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.dto.StartSessionResponse
 import br.inatel.tcc.service.redis.LeaderboardRedisService
@@ -53,7 +54,6 @@ class TrainSessionService(
         val user = userRepository.findByEmail(userEmail)
             .orElseThrow { IllegalArgumentException("Usuário não encontrado: $userEmail") }
 
-        // Busca a Horda no PostgreSQL apenas uma vez — o targetPace é cacheado no Redis
         val horde = request.hordeId?.let {
             hordeRepository.findById(it)
                 .orElseThrow { IllegalArgumentException("Horda não encontrada: $it") }
@@ -73,7 +73,6 @@ class TrainSessionService(
 
         val sessionId = session.id.toString()
 
-        // Inicializa Redis: grava start time + horde pace (evita query ao PostgreSQL durante a corrida)
         leaderboardRedisService.initSession(sessionId, horde?.targetPace)
 
         return StartSessionResponse(sessionId = sessionId)
@@ -85,13 +84,9 @@ class TrainSessionService(
         val session = trainSessionRepository.findById(id)
             .orElseThrow { IllegalArgumentException("Sessão não encontrada: $sessionId") }
 
-        // Lê o ranking final do Redis antes de expirar os keys
         val finalLeaderboard = leaderboardRedisService.getFullLeaderboard(sessionId)
-
-        // Período no formato yyyy-MM para agrupamento no ranking mensal
         val period = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"))
 
-        // Persiste cada posição do ranking no PostgreSQL
         finalLeaderboard?.forEachIndexed { index, entry ->
             val userId = UUID.fromString(entry.value ?: return@forEachIndexed)
             val distanceKm = entry.score ?: 0.0
@@ -108,7 +103,6 @@ class TrainSessionService(
             )
         }
 
-        // Atualiza a sessão com endDate e distância total do próprio usuário dono da sessão
         val ownerDistance = finalLeaderboard
             ?.firstOrNull { it.value == session.user.id.toString() }
             ?.score
@@ -127,7 +121,23 @@ class TrainSessionService(
             )
         )
 
-        // Reduz TTL dos keys Redis para 1h (dados ainda acessíveis brevemente pós-corrida)
         leaderboardRedisService.expireSessionKeys(sessionId)
+    }
+
+    fun getLeaderboard(sessionId: String): List<LeaderboardEntryDto> {
+        val entries = leaderboardRedisService.getTopEntries(sessionId) ?: return emptyList()
+        return entries.mapIndexed { index, tuple ->
+            LeaderboardEntryDto(
+                userId = tuple.value ?: "",
+                rank = index + 1,
+                distanceKm = tuple.score ?: 0.0
+            )
+        }
+    }
+
+    fun getSession(sessionId: String): TrainSession {
+        val id = UUID.fromString(sessionId)
+        return trainSessionRepository.findById(id)
+            .orElseThrow { IllegalArgumentException("Sessão não encontrada: $sessionId") }
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and new features to the training session management in the backend. The most significant changes are the addition of REST endpoints for retrieving session and leaderboard data, updates to endpoint naming for consistency, and some internal code clean-up.

**New REST API Endpoints:**

* Added `GET /sessions/{sessionId}/leaderboard` to allow clients to fetch the current leaderboard for a session without requiring a WebSocket connection. (`TrainSessionController.kt`, `TrainSessionService.kt`) [[1]](diffhunk://#diff-20e9080dbb220856b922c6cc8808f8ec8c1d182f7939e1bfcd6bacf63c4d597eL52-R57) [[2]](diffhunk://#diff-8825e2a6c2df117578ff9751724ece88d27de8bfc26f705b80cf26b0b0af9e95L130-R142)
* Added `GET /sessions/{sessionId}` to retrieve session details by ID. (`TrainSessionController.kt`, `TrainSessionService.kt`) [[1]](diffhunk://#diff-20e9080dbb220856b922c6cc8808f8ec8c1d182f7939e1bfcd6bacf63c4d597eL52-R57) [[2]](diffhunk://#diff-8825e2a6c2df117578ff9751724ece88d27de8bfc26f705b80cf26b0b0af9e95L130-R142)

**Endpoint Naming Consistency:**

* Renamed REST endpoints from Portuguese to English for clarity and consistency:
  - `/sessions/iniciar` → `/sessions/start`
  - `/sessions/{id}/encerrar` → `/sessions/{id}/finish`
  - WebSocket mapping `/treino/dados` → `/train/data`
  (`TrainSessionController.kt`, `BiometricWebSocketController.kt`) [[1]](diffhunk://#diff-20e9080dbb220856b922c6cc8808f8ec8c1d182f7939e1bfcd6bacf63c4d597eR3-R23) [[2]](diffhunk://#diff-20e9080dbb220856b922c6cc8808f8ec8c1d182f7939e1bfcd6bacf63c4d597eL52-R57) [[3]](diffhunk://#diff-8035064ff8833edddd427fd0fee52ce92eedb2341d7461af74766c93acab13dfL43-L58)

**Code Clean-up and Documentation:**

* Removed outdated comments and TODOs from controllers and services to improve code readability. (`TrainSessionController.kt`, `TrainSessionService.kt`, `BiometricWebSocketController.kt`) [[1]](diffhunk://#diff-20e9080dbb220856b922c6cc8808f8ec8c1d182f7939e1bfcd6bacf63c4d597eR3-R23) [[2]](diffhunk://#diff-8825e2a6c2df117578ff9751724ece88d27de8bfc26f705b80cf26b0b0af9e95L56) [[3]](diffhunk://#diff-8825e2a6c2df117578ff9751724ece88d27de8bfc26f705b80cf26b0b0af9e95L76) [[4]](diffhunk://#diff-8825e2a6c2df117578ff9751724ece88d27de8bfc26f705b80cf26b0b0af9e95L88-L94) [[5]](diffhunk://#diff-8825e2a6c2df117578ff9751724ece88d27de8bfc26f705b80cf26b0b0af9e95L111) [[6]](diffhunk://#diff-8825e2a6c2df117578ff9751724ece88d27de8bfc26f705b80cf26b0b0af9e95L130-R142) [[7]](diffhunk://#diff-8035064ff8833edddd427fd0fee52ce92eedb2341d7461af74766c93acab13dfL43-L58) [[8]](diffhunk://#diff-8035064ff8833edddd427fd0fee52ce92eedb2341d7461af74766c93acab13dfL68-L79)

These changes make the API more intuitive for frontend integration and prepare the codebase for future enhancements.