### PR TITLE
Persistência Biométria + Achivements + Horda Adaptativa

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,15 @@ services:
       - "${APP_PORT}:${APP_PORT}"
     environment:
       - DB_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_DB}
+      - DB_USER=${POSTGRES_USER}
+      - DB_PASS=${POSTGRES_PASSWORD}
       - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   postgres:
     image: postgres:17

--- a/src/main/kotlin/br/inatel/tcc/TccApplication.kt
+++ b/src/main/kotlin/br/inatel/tcc/TccApplication.kt
@@ -2,8 +2,10 @@ package br.inatel.tcc
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 
 @SpringBootApplication
+@EnableAsync
 class TccApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
@@ -3,6 +3,7 @@ package br.inatel.tcc.controller
 import br.inatel.tcc.dto.BiometricDataMessage
 import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.dto.LeaderboardResponse
+import br.inatel.tcc.service.BiometricPersistenceService
 import br.inatel.tcc.service.HordePositionService
 import br.inatel.tcc.service.redis.LeaderboardRedisService
 import br.inatel.tcc.service.redis.SessionRedisService
@@ -26,11 +27,6 @@ import io.swagger.v3.oas.annotations.tags.Tag
  *
  * Cada operação Redis neste handler leva < 1ms → latência total do handler < 10ms.
  *
- * TODO [FASE 3 - PERSISTÊNCIA BIOMÉTRICA]: Persistir cada BiometricDataMessage no PostgreSQL
- *   de forma assíncrona usando @Async (Spring) ou uma fila em memória (ArrayBlockingQueue)
- *   para não bloquear o fluxo WebSocket. Criar BiometricData entity e associar ao TrainSession.
- *   Referência: domain/biometricdata/BiometricData.kt + BiometricDataRepository
- *
  * TODO [FASE 4 - ZONA CARDÍACA]: Após calcular a zona cardíaca (CardiacZone.kt),
  *   incluí-la no LeaderboardResponse para que o app exiba o ícone de intensidade
  *   de cada competidor em tempo real.
@@ -43,7 +39,8 @@ class BiometricWebSocketController(
     private val leaderboardRedisService: LeaderboardRedisService,
     private val hordePositionService: HordePositionService,
     private val messagingTemplate: SimpMessagingTemplate,
-    private val validator: Validator
+    private val validator: Validator,
+    private val biometricPersistenceService: BiometricPersistenceService
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -60,6 +57,9 @@ class BiometricWebSocketController(
 
         val start = System.currentTimeMillis()
 
+        // Persiste no PostgreSQL de forma assíncrona — não bloqueia o handler
+        biometricPersistenceService.persistAsync(message)
+
         sessionRedisService.saveUserState(message.sessionId, message.userId, message)
         leaderboardRedisService.updateUserDistance(message.sessionId, message.userId, message.accumulatedDistance)
 
@@ -72,6 +72,15 @@ class BiometricWebSocketController(
                     distanceKm = tuple.score ?: 0.0
                 )
             } ?: emptyList()
+
+        // Horda adaptativa: atualiza o pace no Redis com a média dos usuários ativos
+        if (leaderboardRedisService.isHordeAdaptive(message.sessionId) && entries.isNotEmpty()) {
+            val activeUserIds = entries.map { it.userId }
+            val avgPace = sessionRedisService.getAveragePace(message.sessionId, activeUserIds)
+            if (avgPace != null && avgPace > 0) {
+                leaderboardRedisService.updateHordePace(message.sessionId, avgPace)
+            }
+        }
 
         val startEpoch = leaderboardRedisService.getSessionStartEpoch(message.sessionId)
         val hordePace = leaderboardRedisService.getHordePace(message.sessionId)

--- a/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
@@ -6,6 +6,7 @@ import br.inatel.tcc.dto.LeaderboardResponse
 import br.inatel.tcc.service.HordePositionService
 import br.inatel.tcc.service.redis.LeaderboardRedisService
 import br.inatel.tcc.service.redis.SessionRedisService
+import jakarta.validation.Validator
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.simp.SimpMessagingTemplate
@@ -20,7 +21,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
  * Recebe o fluxo de biometria do Galaxy Watch via WebSocket STOMP e
  * atualiza o estado em tempo real no Redis.
  *
- * Canal de entrada:  /app/treino/dados  (prefixo /app configurado em WebSocketConfig)
+ * Canal de entrada:  /app/train/data  (prefixo /app configurado em WebSocketConfig)
  * Canal de saída:    /topic/session/{sessionId}/leaderboard  (broadcast para todos na sessão)
  *
  * Cada operação Redis neste handler leva < 1ms → latência total do handler < 10ms.
@@ -41,7 +42,8 @@ class BiometricWebSocketController(
     private val sessionRedisService: SessionRedisService,
     private val leaderboardRedisService: LeaderboardRedisService,
     private val hordePositionService: HordePositionService,
-    private val messagingTemplate: SimpMessagingTemplate
+    private val messagingTemplate: SimpMessagingTemplate,
+    private val validator: Validator
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -49,6 +51,13 @@ class BiometricWebSocketController(
     @Operation(summary = "Receive biometric data from a user", responses = [ApiResponse(description = "Biometric data received", content = [Content(mediaType = "application/json", schema = Schema(implementation = BiometricDataMessage::class))])])
     @MessageMapping("/train/data")
     fun receiveBiometricData(message: BiometricDataMessage) {
+        val violations = validator.validate(message)
+        if (violations.isNotEmpty()) {
+            log.warn("[BIOMETRIA] Dados inválidos rejeitados sessionId={}: {}",
+                message.sessionId, violations.map { "${it.propertyPath}: ${it.message}" })
+            return
+        }
+
         val start = System.currentTimeMillis()
 
         sessionRedisService.saveUserState(message.sessionId, message.userId, message)

--- a/src/main/kotlin/br/inatel/tcc/domain/horde/Horde.kt
+++ b/src/main/kotlin/br/inatel/tcc/domain/horde/Horde.kt
@@ -24,6 +24,9 @@ class Horde(
 
     val targetPace: Double? = null,
 
+    @Column(nullable = false)
+    val isAdaptive: Boolean = false,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "horde_id", nullable = true)
     val parentHorde: Horde? = null

--- a/src/main/kotlin/br/inatel/tcc/domain/trainsession/TrainSessionRepository.kt
+++ b/src/main/kotlin/br/inatel/tcc/domain/trainsession/TrainSessionRepository.kt
@@ -6,4 +6,5 @@ import java.util.UUID
 interface TrainSessionRepository : JpaRepository<TrainSession, UUID> {
     fun findByUserId(userId: UUID): List<TrainSession>
     fun findByUserIdAndHordeId(userId: UUID, hordeId: UUID): List<TrainSession>
+    fun countByUser_IdAndEndDateIsNotNull(userId: UUID): Long
 }

--- a/src/main/kotlin/br/inatel/tcc/domain/userachievement/UserAchievementRepository.kt
+++ b/src/main/kotlin/br/inatel/tcc/domain/userachievement/UserAchievementRepository.kt
@@ -6,4 +6,5 @@ import java.util.UUID
 interface UserAchievementRepository : JpaRepository<UserAchievement, UserAchievementId> {
     fun findByUserId(userId: UUID): List<UserAchievement>
     fun findByAchievementId(achievementId: UUID): List<UserAchievement>
+    fun existsByIdUserIdAndIdAchievementId(userId: UUID, achievementId: UUID): Boolean
 }

--- a/src/main/kotlin/br/inatel/tcc/dto/BiometricDataMessage.kt
+++ b/src/main/kotlin/br/inatel/tcc/dto/BiometricDataMessage.kt
@@ -1,22 +1,24 @@
 package br.inatel.tcc.dto
 
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.PositiveOrZero
+
 /**
  * Mensagem recebida via WebSocket STOMP do app React Native (companion do Galaxy Watch).
  *
  * O app React Native recebe esses dados do relógio via Wear OS Data Layer API (Bluetooth)
- * e repassa ao backend pelo canal /app/treino/dados.
- *
- * TODO [FASE 2 - VALIDAÇÃO]: Adicionar validações (@NotBlank, @Min) para garantir
- * que dados malformados do relógio não corrompam o leaderboard no Redis.
+ * e repassa ao backend pelo canal /app/train/data.
  */
 data class BiometricDataMessage(
-    val sessionId: String,
-    val userId: String,
-    val timestamp: Long,           // Epoch ms — gerado pelo relógio
-    val bpm: Int,                  // Frequência cardíaca (batimentos por minuto)
-    val cadence: Double,           // Passadas por minuto
-    val speed: Double,             // Velocidade em km/h
-    val pace: Double,              // Ritmo em min/km
-    val accumulatedDistance: Double, // Distância total percorrida na sessão em km
-    val accumulatedCalories: Double  // Calorias estimadas acumuladas
+    @field:NotBlank val sessionId: String,
+    @field:NotBlank val userId: String,
+    @field:Positive val timestamp: Long,           // Epoch ms — gerado pelo relógio
+    @field:Min(1) val bpm: Int,                    // Frequência cardíaca (batimentos por minuto)
+    @field:PositiveOrZero val cadence: Double,     // Passadas por minuto
+    @field:PositiveOrZero val speed: Double,       // Velocidade em km/h
+    @field:PositiveOrZero val pace: Double,        // Ritmo em min/km
+    @field:PositiveOrZero val accumulatedDistance: Double, // Distância total percorrida na sessão em km
+    @field:PositiveOrZero val accumulatedCalories: Double  // Calorias estimadas acumuladas
 )

--- a/src/main/kotlin/br/inatel/tcc/service/AchievementService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/AchievementService.kt
@@ -1,0 +1,92 @@
+package br.inatel.tcc.service
+
+import br.inatel.tcc.domain.achievement.AchievementRepository
+import br.inatel.tcc.domain.trainsession.TrainSession
+import br.inatel.tcc.domain.trainsession.TrainSessionRepository
+import br.inatel.tcc.domain.user.User
+import br.inatel.tcc.domain.userachievement.UserAchievement
+import br.inatel.tcc.domain.userachievement.UserAchievementId
+import br.inatel.tcc.domain.userachievement.UserAchievementRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.ZSetOperations
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Verifica e concede conquistas ao usuário ao encerrar uma sessão de treino.
+ *
+ * Critérios suportados (campo Achievement.criterion):
+ *   FIRST_RUN    — primeira sessão completada pelo usuário
+ *   DISTANCE_5KM — correu ≥ 5km na sessão
+ *   HORDE_TOP_1  — terminou em 1º lugar com horda ativa
+ *
+ * Apenas achievements com active=true são avaliados.
+ * Achievements já concedidos anteriormente são ignorados (idempotente).
+ */
+@Service
+class AchievementService(
+    private val achievementRepository: AchievementRepository,
+    private val userAchievementRepository: UserAchievementRepository,
+    private val trainSessionRepository: TrainSessionRepository
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun verifyAndGrant(
+        user: User,
+        session: TrainSession,
+        finalLeaderboard: Set<ZSetOperations.TypedTuple<String>>?
+    ) {
+        val activeAchievements = achievementRepository.findByActive(true)
+        if (activeAchievements.isEmpty()) return
+
+        for (achievement in activeAchievements) {
+            val achievementId = achievement.id ?: continue
+            val userId = user.id ?: continue
+
+            if (userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievementId)) continue
+
+            val shouldGrant = when (achievement.criterion) {
+                "FIRST_RUN"    -> isFirstRun(user)
+                "DISTANCE_5KM" -> hasRunFiveKm(user, finalLeaderboard)
+                "HORDE_TOP_1"  -> isHordeTopOne(user, session, finalLeaderboard)
+                else           -> false
+            }
+
+            if (shouldGrant) {
+                userAchievementRepository.save(
+                    UserAchievement(
+                        id = UserAchievementId(userId = userId, achievementId = achievementId),
+                        user = user,
+                        achievement = achievement
+                    )
+                )
+                log.info("[ACHIEVEMENT] Conquista '{}' concedida ao usuário {}", achievement.title, user.email)
+            }
+        }
+    }
+
+    /** Verifica se esta foi a primeira sessão completada do usuário. */
+    private fun isFirstRun(user: User): Boolean =
+        trainSessionRepository.countByUser_IdAndEndDateIsNotNull(user.id!!) == 1L
+
+    /** Verifica se o usuário percorreu pelo menos 5km nesta sessão. */
+    private fun hasRunFiveKm(user: User, leaderboard: Set<ZSetOperations.TypedTuple<String>>?): Boolean {
+        val distance = leaderboard
+            ?.firstOrNull { it.value == user.id.toString() }
+            ?.score ?: 0.0
+        return distance >= 5.0
+    }
+
+    /** Verifica se o usuário terminou em 1º lugar em uma sessão com horda. */
+    private fun isHordeTopOne(
+        user: User,
+        session: TrainSession,
+        leaderboard: Set<ZSetOperations.TypedTuple<String>>?
+    ): Boolean {
+        if (session.horde == null) return false
+        val topEntry = leaderboard?.firstOrNull() ?: return false
+        return topEntry.value == user.id.toString()
+    }
+}

--- a/src/main/kotlin/br/inatel/tcc/service/BiometricPersistenceService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/BiometricPersistenceService.kt
@@ -1,0 +1,56 @@
+package br.inatel.tcc.service
+
+import br.inatel.tcc.domain.biometricdata.BiometricData
+import br.inatel.tcc.domain.biometricdata.BiometricDataRepository
+import br.inatel.tcc.domain.trainsession.TrainSessionRepository
+import br.inatel.tcc.dto.BiometricDataMessage
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Persiste dados biométricos no PostgreSQL de forma assíncrona,
+ * sem bloquear o fluxo do WebSocket handler (< 10ms target).
+ *
+ * Cada chamada a persistAsync() é executada em thread separada do pool de async do Spring.
+ * A TrainSession é buscada dentro do método assíncrono para garantir contexto JPA válido.
+ */
+@Service
+class BiometricPersistenceService(
+    private val biometricDataRepository: BiometricDataRepository,
+    private val trainSessionRepository: TrainSessionRepository
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Async
+    @Transactional
+    fun persistAsync(message: BiometricDataMessage) {
+        val sessionId = runCatching { UUID.fromString(message.sessionId) }.getOrNull() ?: return
+
+        val session = trainSessionRepository.findById(sessionId).orElse(null)
+        if (session == null) {
+            log.warn("[BIOMETRIA-ASYNC] Sessão não encontrada para persistência: {}", message.sessionId)
+            return
+        }
+
+        biometricDataRepository.save(
+            BiometricData(
+                timestamp = Instant.ofEpochMilli(message.timestamp)
+                    .atZone(ZoneOffset.UTC)
+                    .toLocalDateTime(),
+                bpm = message.bpm,
+                cadence = message.cadence,
+                speed = message.speed,
+                pace = message.pace,
+                accumulatedDistance = message.accumulatedDistance,
+                accumulatedCalories = message.accumulatedCalories,
+                trainSession = session
+            )
+        )
+    }
+}

--- a/src/main/kotlin/br/inatel/tcc/service/HordePositionService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/HordePositionService.kt
@@ -1,5 +1,6 @@
 package br.inatel.tcc.service
 
+import br.inatel.tcc.domain.horde.Horde
 import org.springframework.stereotype.Service
 
 /**
@@ -15,10 +16,6 @@ import org.springframework.stereotype.Service
  *   - O tempo decorrido é derivado do clock atual + start time já no Redis
  *   - Sem I/O adicional — cálculo puramente local (< 1µs)
  *   - Resultado sempre fresco (não fica desatualizado em cache)
- *
- * TODO [FASE 2 - HORDA DINÂMICA]: Suportar hordes com parentHorde (Horde.parentHorde).
- *   A posição de uma sub-horda pode ter um multiplicador ou offset relativo à horda pai.
- *   Referência: domain/horde/Horde.kt (campo parentHorde)
  *
  * TODO [FASE 3 - HORDA ADAPTATIVA]: Implementar modo onde o pace da Horda se adapta
  *   dinamicamente à performance média dos usuários ativos na sessão.
@@ -36,4 +33,15 @@ class HordePositionService {
         val elapsedMinutes = elapsedSeconds / 60.0
         return elapsedMinutes / targetPaceMinPerKm
     }
+
+    /**
+     * Resolve o pace efetivo de uma Horda considerando herança de sub-hordas.
+     *
+     * Sub-hordas sem targetPace próprio herdam o pace da horda pai, permitindo
+     * criar variações de dificuldade sem duplicar a configuração.
+     *
+     * @return targetPace da horda ou do pai; null se nenhum dos dois tiver pace definido
+     */
+    fun resolveEffectivePace(horde: Horde): Double? =
+        horde.targetPace ?: horde.parentHorde?.targetPace
 }

--- a/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
@@ -29,10 +29,6 @@ import java.util.UUID
  *   Durante a corrida → apenas Redis (< 1ms por operação)
  *   Ao encerrar       → flush para PostgreSQL (rankings + sessão)
  *
- * TODO [FASE 3 - ACHIEVEMENTS]: Após persistir o ranking, verificar critérios de conquistas
- *   (ex: primeira corrida completada, 5km, top 1 na Horda) e registrar em UserAchievement.
- *   Referência: domain/userachievement/UserAchievement.kt + domain/achievement/Achievement.kt
- *
  * TODO [FASE 4 - AMIGOS]: Ao encerrar, notificar amigos do usuário via WebSocket
  *   sobre o resultado da sessão.
  *   Referência: domain/friendship/FriendshipRepository.kt
@@ -47,7 +43,8 @@ class TrainSessionService(
     private val hordeRepository: HordeRepository,
     private val rankingRepository: RankingRepository,
     private val leaderboardRedisService: LeaderboardRedisService,
-    private val hordePositionService: HordePositionService
+    private val hordePositionService: HordePositionService,
+    private val achievementService: AchievementService
 ) {
 
     @Transactional
@@ -74,7 +71,11 @@ class TrainSessionService(
 
         val sessionId = session.id.toString()
 
-        leaderboardRedisService.initSession(sessionId, horde?.let { hordePositionService.resolveEffectivePace(it) })
+        leaderboardRedisService.initSession(
+            sessionId,
+            horde?.let { hordePositionService.resolveEffectivePace(it) },
+            horde?.isAdaptive ?: false
+        )
 
         return StartSessionResponse(sessionId = sessionId)
     }
@@ -108,7 +109,7 @@ class TrainSessionService(
             ?.firstOrNull { it.value == session.user.id.toString() }
             ?.score
 
-        trainSessionRepository.save(
+        val updatedSession = trainSessionRepository.save(
             TrainSession(
                 id = session.id,
                 user = session.user,
@@ -123,6 +124,8 @@ class TrainSessionService(
         )
 
         leaderboardRedisService.expireSessionKeys(sessionId)
+
+        achievementService.verifyAndGrant(session.user, updatedSession, finalLeaderboard)
     }
 
     fun getLeaderboard(sessionId: String): List<LeaderboardEntryDto> {

--- a/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
@@ -46,7 +46,8 @@ class TrainSessionService(
     private val userRepository: UserRepository,
     private val hordeRepository: HordeRepository,
     private val rankingRepository: RankingRepository,
-    private val leaderboardRedisService: LeaderboardRedisService
+    private val leaderboardRedisService: LeaderboardRedisService,
+    private val hordePositionService: HordePositionService
 ) {
 
     @Transactional
@@ -73,7 +74,7 @@ class TrainSessionService(
 
         val sessionId = session.id.toString()
 
-        leaderboardRedisService.initSession(sessionId, horde?.targetPace)
+        leaderboardRedisService.initSession(sessionId, horde?.let { hordePositionService.resolveEffectivePace(it) })
 
         return StartSessionResponse(sessionId = sessionId)
     }

--- a/src/main/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisService.kt
@@ -9,9 +9,10 @@ import java.time.Duration
  * Gerencia o leaderboard da sessão de treino no Redis usando Sorted Sets (ZSET).
  *
  * Estrutura de keys Redis:
- *   session:{sessionId}:leaderboard  → ZSET  member=userId, score=distânciaKm
- *   session:{sessionId}:start        → STRING época em segundos do início da sessão
- *   session:{sessionId}:horde:pace   → STRING targetPace da Horda em min/km (opcional)
+ *   session:{sessionId}:leaderboard    → ZSET  member=userId, score=distânciaKm
+ *   session:{sessionId}:start          → STRING época em segundos do início da sessão
+ *   session:{sessionId}:horde:pace     → STRING targetPace da Horda em min/km (opcional)
+ *   session:{sessionId}:horde:adaptive → STRING "true" se horda é adaptativa (opcional)
  *
  * Por que ZSET para o leaderboard?
  *   - ZADD é O(log N) — atualiza posição e reordena em uma única operação
@@ -30,6 +31,7 @@ class LeaderboardRedisService(
     private fun leaderboardKey(sessionId: String) = "session:$sessionId:leaderboard"
     private fun startKey(sessionId: String) = "session:$sessionId:start"
     private fun hordeKey(sessionId: String) = "session:$sessionId:horde:pace"
+    private fun hordeAdaptiveKey(sessionId: String) = "session:$sessionId:horde:adaptive"
 
     /**
      * Inicializa os metadados da sessão no Redis.
@@ -37,7 +39,7 @@ class LeaderboardRedisService(
      *
      * Usa verificação de existência para ser idempotente — reconexões não sobrescrevem o start.
      */
-    fun initSession(sessionId: String, targetPaceMinPerKm: Double?) {
+    fun initSession(sessionId: String, targetPaceMinPerKm: Double?, isAdaptive: Boolean = false) {
         val startKey = startKey(sessionId)
         if (redis.hasKey(startKey) != true) {
             val epochSeconds = System.currentTimeMillis() / 1000
@@ -47,7 +49,23 @@ class LeaderboardRedisService(
             targetPaceMinPerKm?.let {
                 redis.opsForValue().set(hordeKey(sessionId), it.toString(), Duration.ofHours(24))
             }
+
+            if (isAdaptive) {
+                redis.opsForValue().set(hordeAdaptiveKey(sessionId), "true", Duration.ofHours(24))
+            }
         }
+    }
+
+    /** Retorna true se a horda desta sessão está em modo adaptativo. */
+    fun isHordeAdaptive(sessionId: String): Boolean =
+        redis.opsForValue().get(hordeAdaptiveKey(sessionId)) == "true"
+
+    /**
+     * Atualiza o pace da horda no Redis.
+     * Usado pelo modo adaptativo para refletir a performance média atual dos usuários.
+     */
+    fun updateHordePace(sessionId: String, pace: Double) {
+        redis.opsForValue().set(hordeKey(sessionId), pace.toString(), Duration.ofHours(24))
     }
 
     /**
@@ -93,5 +111,6 @@ class LeaderboardRedisService(
         redis.expire(leaderboardKey(sessionId), ttl)
         redis.expire(startKey(sessionId), ttl)
         redis.expire(hordeKey(sessionId), ttl)
+        redis.expire(hordeAdaptiveKey(sessionId), ttl)
     }
 }

--- a/src/main/kotlin/br/inatel/tcc/service/redis/SessionRedisService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/redis/SessionRedisService.kt
@@ -55,4 +55,18 @@ class SessionRedisService(
     fun expireUserKey(sessionId: String, userId: String) {
         redis.expire(userKey(sessionId, userId), Duration.ofHours(1))
     }
+
+    /**
+     * Calcula o pace médio dos usuários ativos na sessão.
+     * Usado pelo modo adaptativo de horda para atualizar o pace em tempo real.
+     *
+     * @param userIds Lista de userIds ativos (obtida do leaderboard ZSET)
+     * @return Média do pace em min/km, ou null se nenhum usuário tiver pace válido
+     */
+    fun getAveragePace(sessionId: String, userIds: List<String>): Double? {
+        val paces = userIds.mapNotNull { userId ->
+            getUserState(sessionId, userId)["pace"]?.toDoubleOrNull()
+        }.filter { it > 0 }
+        return if (paces.isEmpty()) null else paces.average()
+    }
 }

--- a/src/main/resources/db/migration/V3__add_adaptive_horde.sql
+++ b/src/main/resources/db/migration/V3__add_adaptive_horde.sql
@@ -1,0 +1,3 @@
+-- V3: Suporte a horda adaptativa
+-- Permite que uma horda ajuste seu pace dinamicamente à performance média dos usuários.
+ALTER TABLE hordes ADD COLUMN is_adaptive BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
@@ -2,6 +2,7 @@ package br.inatel.tcc.controller
 
 import br.inatel.tcc.dto.BiometricDataMessage
 import br.inatel.tcc.dto.LeaderboardEntryDto
+import br.inatel.tcc.service.BiometricPersistenceService
 import br.inatel.tcc.service.HordePositionService
 import br.inatel.tcc.service.redis.LeaderboardRedisService
 import br.inatel.tcc.service.redis.SessionRedisService
@@ -31,6 +32,7 @@ class BiometricWebSocketControllerTest {
     @Mock private lateinit var hordePositionService: HordePositionService
     @Mock private lateinit var messagingTemplate: SimpMessagingTemplate
     @Mock private lateinit var validator: Validator
+    @Mock private lateinit var biometricPersistenceService: BiometricPersistenceService
 
     @InjectMocks private lateinit var controller: BiometricWebSocketController
 
@@ -178,6 +180,32 @@ class BiometricWebSocketControllerTest {
 
         verify(messagingTemplate).convertAndSend(any<String>(), captor.capture())
         assert(captor.firstValue.userRank == 1)
+    }
+
+    @Test
+    fun shouldUpdateHordePace_whenHordeIsAdaptive() {
+        val message = buildMessage()
+        setupLeaderboardMocks(rank = 0L)
+        whenever(leaderboardRedisService.isHordeAdaptive(sessionId)).thenReturn(true)
+        whenever(leaderboardRedisService.getTopEntries(sessionId, 10)).thenReturn(
+            linkedSetOf(org.springframework.data.redis.core.DefaultTypedTuple(userId, 2.5))
+        )
+        whenever(sessionRedisService.getAveragePace(sessionId, listOf(userId))).thenReturn(5.5)
+
+        controller.receiveBiometricData(message)
+
+        verify(leaderboardRedisService).updateHordePace(sessionId, 5.5)
+    }
+
+    @Test
+    fun shouldNotUpdateHordePace_whenHordeIsNotAdaptive() {
+        val message = buildMessage()
+        setupLeaderboardMocks(rank = 0L)
+        whenever(leaderboardRedisService.isHordeAdaptive(sessionId)).thenReturn(false)
+
+        controller.receiveBiometricData(message)
+
+        verify(leaderboardRedisService, never()).updateHordePace(any(), any())
     }
 
     @Test

--- a/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
@@ -5,6 +5,8 @@ import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.service.HordePositionService
 import br.inatel.tcc.service.redis.LeaderboardRedisService
 import br.inatel.tcc.service.redis.SessionRedisService
+import jakarta.validation.ConstraintViolation
+import jakarta.validation.Validator
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -13,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -27,6 +30,7 @@ class BiometricWebSocketControllerTest {
     @Mock private lateinit var leaderboardRedisService: LeaderboardRedisService
     @Mock private lateinit var hordePositionService: HordePositionService
     @Mock private lateinit var messagingTemplate: SimpMessagingTemplate
+    @Mock private lateinit var validator: Validator
 
     @InjectMocks private lateinit var controller: BiometricWebSocketController
 
@@ -174,6 +178,17 @@ class BiometricWebSocketControllerTest {
 
         verify(messagingTemplate).convertAndSend(any<String>(), captor.capture())
         assert(captor.firstValue.userRank == 1)
+    }
+
+    @Test
+    fun shouldRejectMessageWhenValidationFails() {
+        val message = buildMessage()
+        val violation = mock<ConstraintViolation<BiometricDataMessage>>()
+        whenever(validator.validate(message)).thenReturn(setOf(violation))
+
+        controller.receiveBiometricData(message)
+
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<LeaderboardResponse>())
     }
 
     // ─── Helpers ──────────────────────────────────────────────────────────────

--- a/src/test/kotlin/br/inatel/tcc/service/AchievementServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/AchievementServiceTest.kt
@@ -1,0 +1,180 @@
+package br.inatel.tcc.service
+
+import br.inatel.tcc.domain.achievement.Achievement
+import br.inatel.tcc.domain.achievement.AchievementRepository
+import br.inatel.tcc.domain.horde.Horde
+import br.inatel.tcc.domain.horde.HordeDifficulty
+import br.inatel.tcc.domain.trainsession.TrainSession
+import br.inatel.tcc.domain.trainsession.TrainSessionRepository
+import br.inatel.tcc.domain.user.User
+import br.inatel.tcc.domain.userachievement.UserAchievement
+import br.inatel.tcc.domain.userachievement.UserAchievementRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.DefaultTypedTuple
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class AchievementServiceTest {
+
+    @Mock private lateinit var achievementRepository: AchievementRepository
+    @Mock private lateinit var userAchievementRepository: UserAchievementRepository
+    @Mock private lateinit var trainSessionRepository: TrainSessionRepository
+
+    @InjectMocks private lateinit var service: AchievementService
+
+    private val userId = UUID.randomUUID()
+    private val user = User(id = userId, email = "test@test.com", name = "Test", password = "enc")
+
+    private fun buildAchievement(criterion: String) = Achievement(
+        id = UUID.randomUUID(), title = "Achievement $criterion", criterion = criterion
+    )
+
+    private fun buildSession(horde: Horde? = null) = TrainSession(
+        id = UUID.randomUUID(), user = user, horde = horde
+    )
+
+    private fun buildHorde() = Horde(
+        id = UUID.randomUUID(), name = "Horda", difficulty = HordeDifficulty.MEDIUM, estimatedDuration = 30
+    )
+
+    // ─── FIRST_RUN ────────────────────────────────────────────────────────────
+
+    @Test
+    fun shouldGrantFirstRun_whenFirstCompletedSession() {
+        val achievement = buildAchievement("FIRST_RUN")
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+        whenever(trainSessionRepository.countByUser_IdAndEndDateIsNotNull(userId)).thenReturn(1L)
+        whenever(userAchievementRepository.save(any<UserAchievement>())).thenAnswer { it.arguments[0] }
+
+        service.verifyAndGrant(user, buildSession(), emptySet())
+
+        verify(userAchievementRepository).save(any<UserAchievement>())
+    }
+
+    @Test
+    fun shouldNotGrantFirstRun_whenMultipleSessionsCompleted() {
+        val achievement = buildAchievement("FIRST_RUN")
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+        whenever(trainSessionRepository.countByUser_IdAndEndDateIsNotNull(userId)).thenReturn(3L)
+
+        service.verifyAndGrant(user, buildSession(), emptySet())
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    // ─── DISTANCE_5KM ─────────────────────────────────────────────────────────
+
+    @Test
+    fun shouldGrantDistance5km_whenUserRanFiveOrMoreKm() {
+        val achievement = buildAchievement("DISTANCE_5KM")
+        val leaderboard = linkedSetOf(DefaultTypedTuple(userId.toString(), 5.0))
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+        whenever(userAchievementRepository.save(any<UserAchievement>())).thenAnswer { it.arguments[0] }
+
+        service.verifyAndGrant(user, buildSession(), leaderboard)
+
+        verify(userAchievementRepository).save(any<UserAchievement>())
+    }
+
+    @Test
+    fun shouldNotGrantDistance5km_whenUserRanLessThanFiveKm() {
+        val achievement = buildAchievement("DISTANCE_5KM")
+        val leaderboard = linkedSetOf(DefaultTypedTuple(userId.toString(), 4.9))
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+
+        service.verifyAndGrant(user, buildSession(), leaderboard)
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    // ─── HORDE_TOP_1 ──────────────────────────────────────────────────────────
+
+    @Test
+    fun shouldGrantHordeTop1_whenUserFinishedFirstWithHorde() {
+        val achievement = buildAchievement("HORDE_TOP_1")
+        val leaderboard = linkedSetOf(
+            DefaultTypedTuple(userId.toString(), 5.0),
+            DefaultTypedTuple(UUID.randomUUID().toString(), 3.0)
+        )
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+        whenever(userAchievementRepository.save(any<UserAchievement>())).thenAnswer { it.arguments[0] }
+
+        service.verifyAndGrant(user, buildSession(horde = buildHorde()), leaderboard)
+
+        verify(userAchievementRepository).save(any<UserAchievement>())
+    }
+
+    @Test
+    fun shouldNotGrantHordeTop1_whenSessionHasNoHorde() {
+        val achievement = buildAchievement("HORDE_TOP_1")
+        val leaderboard = linkedSetOf(DefaultTypedTuple(userId.toString(), 5.0))
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+
+        service.verifyAndGrant(user, buildSession(horde = null), leaderboard)
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    @Test
+    fun shouldNotGrantHordeTop1_whenUserIsNotFirst() {
+        val achievement = buildAchievement("HORDE_TOP_1")
+        val otherId = UUID.randomUUID()
+        val leaderboard = linkedSetOf(
+            DefaultTypedTuple(otherId.toString(), 6.0),
+            DefaultTypedTuple(userId.toString(), 5.0)
+        )
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+
+        service.verifyAndGrant(user, buildSession(horde = buildHorde()), leaderboard)
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    // ─── Casos gerais ─────────────────────────────────────────────────────────
+
+    @Test
+    fun shouldNotGrant_whenAchievementAlreadyConceded() {
+        val achievement = buildAchievement("FIRST_RUN")
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(true)
+
+        service.verifyAndGrant(user, buildSession(), emptySet())
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    @Test
+    fun shouldDoNothing_whenNoActiveAchievements() {
+        whenever(achievementRepository.findByActive(true)).thenReturn(emptyList())
+
+        service.verifyAndGrant(user, buildSession(), emptySet())
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    @Test
+    fun shouldIgnoreUnknownCriterion() {
+        val achievement = buildAchievement("UNKNOWN_CRITERION")
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+
+        service.verifyAndGrant(user, buildSession(), emptySet())
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+}

--- a/src/test/kotlin/br/inatel/tcc/service/BiometricPersistenceServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/BiometricPersistenceServiceTest.kt
@@ -1,0 +1,80 @@
+package br.inatel.tcc.service
+
+import br.inatel.tcc.domain.biometricdata.BiometricData
+import br.inatel.tcc.domain.biometricdata.BiometricDataRepository
+import br.inatel.tcc.domain.trainsession.TrainSession
+import br.inatel.tcc.domain.trainsession.TrainSessionRepository
+import br.inatel.tcc.domain.user.User
+import br.inatel.tcc.dto.BiometricDataMessage
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class BiometricPersistenceServiceTest {
+
+    @Mock private lateinit var biometricDataRepository: BiometricDataRepository
+    @Mock private lateinit var trainSessionRepository: TrainSessionRepository
+
+    @InjectMocks private lateinit var service: BiometricPersistenceService
+
+    private val sessionId = UUID.randomUUID()
+    private val userId = UUID.randomUUID()
+
+    private fun buildMessage(sid: String = sessionId.toString()) = BiometricDataMessage(
+        sessionId = sid,
+        userId = userId.toString(),
+        timestamp = System.currentTimeMillis(),
+        bpm = 155,
+        cadence = 80.0,
+        speed = 10.0,
+        pace = 6.0,
+        accumulatedDistance = 2.5,
+        accumulatedCalories = 120.0
+    )
+
+    private fun buildSession() = TrainSession(
+        id = sessionId,
+        user = User(id = userId, email = "test@test.com", name = "Test", password = "enc")
+    )
+
+    @Test
+    fun shouldSaveBiometricData_whenSessionExists() {
+        val message = buildMessage()
+        val session = buildSession()
+        whenever(trainSessionRepository.findById(sessionId)).thenReturn(Optional.of(session))
+        whenever(biometricDataRepository.save(any<BiometricData>())).thenAnswer { it.arguments[0] }
+
+        service.persistAsync(message)
+
+        verify(biometricDataRepository).save(any<BiometricData>())
+    }
+
+    @Test
+    fun shouldNotSave_whenSessionNotFound() {
+        val message = buildMessage()
+        whenever(trainSessionRepository.findById(sessionId)).thenReturn(Optional.empty())
+
+        service.persistAsync(message)
+
+        verify(biometricDataRepository, never()).save(any())
+    }
+
+    @Test
+    fun shouldNotSave_whenSessionIdIsInvalidUUID() {
+        val message = buildMessage(sid = "not-a-uuid")
+
+        service.persistAsync(message)
+
+        verify(trainSessionRepository, never()).findById(any())
+        verify(biometricDataRepository, never()).save(any())
+    }
+}

--- a/src/test/kotlin/br/inatel/tcc/service/HordePositionServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/HordePositionServiceTest.kt
@@ -1,6 +1,9 @@
 package br.inatel.tcc.service
 
+import br.inatel.tcc.domain.horde.Horde
+import br.inatel.tcc.domain.horde.HordeDifficulty
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -13,6 +16,10 @@ class HordePositionServiceTest {
     fun setUp() {
         service = HordePositionService()
     }
+
+    private fun buildHorde(targetPace: Double? = null, parentHorde: Horde? = null) =
+        Horde(name = "Test", difficulty = HordeDifficulty.MEDIUM, estimatedDuration = 30,
+            targetPace = targetPace, parentHorde = parentHorde)
 
     @Test
     fun shouldReturnNearZero_whenStartIsNow() {
@@ -55,5 +62,40 @@ class HordePositionServiceTest {
 
         // 10 min / 10.0 min/km = 1.0 km
         assertEquals(1.0, result, 0.05)
+    }
+
+    // ─── resolveEffectivePace ─────────────────────────────────────────────────
+
+    @Test
+    fun shouldReturnOwnPace_whenHordeHasTargetPace() {
+        val horde = buildHorde(targetPace = 6.0)
+        assertEquals(6.0, service.resolveEffectivePace(horde))
+    }
+
+    @Test
+    fun shouldReturnParentPace_whenSubHordeHasNoPace() {
+        val parent = buildHorde(targetPace = 5.0)
+        val subHorde = buildHorde(targetPace = null, parentHorde = parent)
+        assertEquals(5.0, service.resolveEffectivePace(subHorde))
+    }
+
+    @Test
+    fun shouldPreferOwnPace_overParentPace() {
+        val parent = buildHorde(targetPace = 5.0)
+        val subHorde = buildHorde(targetPace = 7.0, parentHorde = parent)
+        assertEquals(7.0, service.resolveEffectivePace(subHorde))
+    }
+
+    @Test
+    fun shouldReturnNull_whenStandaloneHordeHasNoPace() {
+        val horde = buildHorde(targetPace = null)
+        assertNull(service.resolveEffectivePace(horde))
+    }
+
+    @Test
+    fun shouldReturnNull_whenBothHordeAndParentHaveNoPace() {
+        val parent = buildHorde(targetPace = null)
+        val subHorde = buildHorde(targetPace = null, parentHorde = parent)
+        assertNull(service.resolveEffectivePace(subHorde))
     }
 }

--- a/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
@@ -11,6 +11,7 @@ import br.inatel.tcc.domain.user.User
 import br.inatel.tcc.domain.user.UserRepository
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.service.redis.LeaderboardRedisService
+import br.inatel.tcc.service.AchievementService
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -36,6 +37,7 @@ class TrainSessionServiceTest {
     @Mock private lateinit var rankingRepository: RankingRepository
     @Mock private lateinit var leaderboardRedisService: LeaderboardRedisService
     @Mock private lateinit var hordePositionService: HordePositionService
+    @Mock private lateinit var achievementService: AchievementService
 
     @InjectMocks private lateinit var service: TrainSessionService
 

--- a/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
@@ -35,6 +35,7 @@ class TrainSessionServiceTest {
     @Mock private lateinit var hordeRepository: HordeRepository
     @Mock private lateinit var rankingRepository: RankingRepository
     @Mock private lateinit var leaderboardRedisService: LeaderboardRedisService
+    @Mock private lateinit var hordePositionService: HordePositionService
 
     @InjectMocks private lateinit var service: TrainSessionService
 
@@ -74,11 +75,29 @@ class TrainSessionServiceTest {
         whenever(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(buildUser()))
         whenever(hordeRepository.findById(hordeId)).thenReturn(Optional.of(horde))
         whenever(trainSessionRepository.save(any())).thenReturn(savedSession)
+        whenever(hordePositionService.resolveEffectivePace(horde)).thenReturn(6.0)
 
         val response = service.startSession("test@example.com", StartSessionRequest(hordeId = hordeId))
 
         assertNotNull(response.sessionId)
         verify(leaderboardRedisService).initSession(sessionId.toString(), 6.0)
+    }
+
+    @Test
+    fun shouldInheritParentPace_forSubHordeWithoutOwnPace() {
+        val parentId = UUID.randomUUID()
+        val subHordeId = UUID.randomUUID()
+        val parent = Horde(id = parentId, name = "Horda Pai", difficulty = HordeDifficulty.EASY, estimatedDuration = 30, targetPace = 5.0)
+        val subHorde = Horde(id = subHordeId, name = "Sub-Horda", difficulty = HordeDifficulty.MEDIUM, estimatedDuration = 30, targetPace = null, parentHorde = parent)
+        val savedSession = buildSession(subHorde)
+        whenever(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(buildUser()))
+        whenever(hordeRepository.findById(subHordeId)).thenReturn(Optional.of(subHorde))
+        whenever(trainSessionRepository.save(any())).thenReturn(savedSession)
+        whenever(hordePositionService.resolveEffectivePace(subHorde)).thenReturn(5.0)
+
+        service.startSession("test@example.com", StartSessionRequest(hordeId = subHordeId))
+
+        verify(leaderboardRedisService).initSession(sessionId.toString(), 5.0)
     }
 
     @Test

--- a/src/test/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisServiceTest.kt
@@ -152,12 +152,13 @@ class LeaderboardRedisServiceTest {
     // ─── expireSessionKeys ────────────────────────────────────────────────────
 
     @Test
-    fun shouldExpireAllThreeKeys() {
+    fun shouldExpireAllKeys() {
         service.expireSessionKeys(sessionId)
 
-        verify(redis, times(3)).expire(any(), eq(Duration.ofHours(1)))
+        verify(redis, times(4)).expire(any(), eq(Duration.ofHours(1)))
         verify(redis).expire(leaderboardKey, Duration.ofHours(1))
         verify(redis).expire(startKey, Duration.ofHours(1))
         verify(redis).expire(hordeKey, Duration.ofHours(1))
+        verify(redis).expire("session:$sessionId:horde:adaptive", Duration.ofHours(1))
     }
 }


### PR DESCRIPTION
**1. Persistência Biométrica Assíncrona:**
- @EnableAsync em TccApplication.kt
- BiometricPersistenceService (novo): método @Async @Transactional persistAsync() busca a TrainSession e salva BiometricData no PostgreSQL em thread separada, sem bloquear o WebSocket handler
- BiometricWebSocketController: chama persistAsync(message) como primeira operação após validação

**2. Achievements:**
- AchievementService (novo): itera achievements ativos, verifica se já foi concedido (existsByIdUserIdAndIdAchievementId), avalia critério e grava UserAchievement
            - FIRST_RUN — conta sessões completadas do usuário
            - DISTANCE_5KM — verifica distância no leaderboard final
            - HORDE_TOP_1 — verifica se sessão tinha horda e usuário estava em 1º
- TrainSessionRepository: countByUser_IdAndEndDateIsNotNull
- UserAchievementRepository: existsByIdUserIdAndIdAchievementId
- TrainSessionService: chama achievementService.verifyAndGrant() ao encerrar sessão

**3. Horda Adaptativa**
- Migration V3: ALTER TABLE hordes ADD COLUMN is_adaptive BOOLEAN NOT NULL DEFAULT FALSE
- Horde.kt: campo isAdaptive: Boolean
- LeaderboardRedisService: initSession aceita isAdaptive, novos métodos isHordeAdaptive(), updateHordePace() e chave horde:adaptive no expire
- SessionRedisService: getAveragePace(sessionId, userIds) calcula média do pace dos usuários ativos
- BiometricWebSocketController: se horda é adaptativa, atualiza o pace no Redis a cada ciclo com a média atual