### PR TITLE
Zona Cardíaca + Campos Horda + Notificação de Amigos

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,5 @@
 .git
 .github
-target
-*.md
 *.html
 .gitignore
 docker-compose.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,13 +191,17 @@ jobs:
     name: Deploy
     needs: [tests, coverage]
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup JDK 25
-        uses: actions/setup-java@v4
+      - name: Deploy to DigitalOcean Droplet
+        uses: appleboy/ssh-action@v1.0.3
         with:
-          java-version: '25'
-          distribution: 'temurin'
-          cache: 'maven'
+          host: ${{ secrets.DO_HOST }}
+          username: ${{ secrets.DO_USERNAME }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          script: |
+            cd ${{ secrets.PROJECT_PATH }}
+            git pull origin main
+            docker-compose down
+            docker-compose up -d --build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,29 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
-      - name: Deploy to DigitalOcean Droplet
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build project JAR
+        run: ./mvnw clean package -DskipTests
+
+      - name: Copy JAR to DigitalOcean Droplet
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DO_HOST }}
+          username: ${{ secrets.DO_USERNAME }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          source: "target/*.jar"
+          target: ${{ secrets.PROJECT_PATH }}
+          strip_components: 0
+
+      - name: Restart Docker Containers
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.DO_HOST }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,10 @@ USER app
 EXPOSE 8080
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport \
-    -Xmx300m \
-    -Xms300m \
+    -Xmx256m \
+    -Xms256m \
+    -XX:MaxMetaspaceSize=80m \
+    -Xss256k \
     -XX:+UseSerialGC \
     -Djava.security.egd=file:/dev/./urandom \
     -Dspring.profiles.active=prod"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,11 @@
-# ─── Stage 1: Build ───────────────────────────────────────────────────────────
-FROM maven:3.9-eclipse-temurin-23 AS builder
-
-WORKDIR /build
-
-COPY pom.xml .
-COPY src ./src
-
-# A flag -B (batch-mode) ajuda a formatar os logs no Docker sem travar
-RUN mvn clean package -DskipTests -B
-
-# ─── Stage 2: Extract layers (Spring Boot layertools) ─────────────────────────
+# ─── Stage 1: Extract layers (Spring Boot layertools) ─────────────────────────
 FROM eclipse-temurin:23-jre-alpine AS extractor
 
 WORKDIR /extract
-COPY --from=builder /build/target/*.jar app.jar
+COPY target/*.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract
 
-# ─── Stage 3: Runtime ─────────────────────────────────────────────────────────
+# ─── Stage 2: Runtime ─────────────────────────────────────────────────────────
 FROM eclipse-temurin:23-jre
 
 RUN groupadd -r app && useradd -r -g app app
@@ -33,9 +22,10 @@ USER app
 EXPOSE 8080
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport \
-               -XX:MaxRAMPercentage=75.0 \
-               -XX:+UseG1GC \
-               -Djava.security.egd=file:/dev/./urandom \
-               -Dspring.profiles.active=prod"
+    -Xmx300m \
+    -Xms300m \
+    -XX:+UseSerialGC \
+    -Djava.security.egd=file:/dev/./urandom \
+    -Dspring.profiles.active=prod"
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ USER app
 EXPOSE 8080
 
 ENV JAVA_OPTS="-XX:+UseContainerSupport \
-    -Xmx256m \
-    -Xms256m \
-    -XX:MaxMetaspaceSize=80m \
-    -Xss256k \
+    -Xmx200m \
+    -Xms128m \
+    -XX:MaxMetaspaceSize=160m \
+    -Xss512k \
     -XX:+UseSerialGC \
     -Djava.security.egd=file:/dev/./urandom \
     -Dspring.profiles.active=prod"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ COPY --from=builder /build/target/*.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract
 
 # ─── Stage 3: Runtime ─────────────────────────────────────────────────────────
-FROM eclipse-temurin:23-jre-alpine
+FROM eclipse-temurin:23-jre
 
-RUN addgroup -S app && adduser -S app -G app
+RUN groupadd -r app && useradd -r -g app app
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,15 @@ services:
       - "${APP_PORT}:${APP_PORT}"
     environment:
       - DB_URL=jdbc:postgresql://postgres:5432/tcc
+      - DB_USER=${POSTGRES_USER}
+      - DB_PASS=${POSTGRES_PASSWORD}
       - REDIS_HOST=redis
     depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    links:
       - postgres
       - redis
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
   postgres:
     image: postgres:17
     restart: unless-stopped
-    ports:
-      - "${POSTGRES_PORT}:${POSTGRES_PORT}"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -33,8 +31,6 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    ports:
-      - "${REDIS_PORT}:${REDIS_PORT}"
     volumes:
       - redis_data:/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ name: tcc
 
 services:
   app:
+    build: .
     image: tcc-backend:latest
     ports:
       - "${APP_PORT}:${APP_PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     ports:
       - "${APP_PORT}:${APP_PORT}"
     environment:
-      - DB_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_DB}
-      - REDIS_HOST=${REDIS_HOST}
+      - DB_URL=jdbc:postgresql://postgres:5432/tcc
+      - REDIS_HOST=redis
     depends_on:
       - postgres
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,12 @@ services:
       - DB_USER=${POSTGRES_USER}
       - DB_PASS=${POSTGRES_PASSWORD}
       - REDIS_HOST=redis
+    deploy:
+      resources:
+        limits:
+          memory: 450M
+        reservations:
+          memory: 300M
 
     depends_on:
       postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - DB_USER=${POSTGRES_USER}
       - DB_PASS=${POSTGRES_PASSWORD}
       - REDIS_HOST=redis
+
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 450M
+          memory: 600M
         reservations:
-          memory: 300M
+          memory: 400M
 
     depends_on:
       postgres:

--- a/src/main/kotlin/br/inatel/tcc/TccApplication.kt
+++ b/src/main/kotlin/br/inatel/tcc/TccApplication.kt
@@ -2,8 +2,10 @@ package br.inatel.tcc
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 
 @SpringBootApplication
+@EnableAsync
 class TccApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
@@ -3,6 +3,7 @@ package br.inatel.tcc.controller
 import br.inatel.tcc.dto.BiometricDataMessage
 import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.dto.LeaderboardResponse
+import br.inatel.tcc.service.BiometricPersistenceService
 import br.inatel.tcc.service.HordePositionService
 import br.inatel.tcc.service.redis.LeaderboardRedisService
 import br.inatel.tcc.service.redis.SessionRedisService
@@ -26,11 +27,6 @@ import io.swagger.v3.oas.annotations.tags.Tag
  *
  * Cada operação Redis neste handler leva < 1ms → latência total do handler < 10ms.
  *
- * TODO [FASE 3 - PERSISTÊNCIA BIOMÉTRICA]: Persistir cada BiometricDataMessage no PostgreSQL
- *   de forma assíncrona usando @Async (Spring) ou uma fila em memória (ArrayBlockingQueue)
- *   para não bloquear o fluxo WebSocket. Criar BiometricData entity e associar ao TrainSession.
- *   Referência: domain/biometricdata/BiometricData.kt + BiometricDataRepository
- *
  * TODO [FASE 4 - ZONA CARDÍACA]: Após calcular a zona cardíaca (CardiacZone.kt),
  *   incluí-la no LeaderboardResponse para que o app exiba o ícone de intensidade
  *   de cada competidor em tempo real.
@@ -43,7 +39,8 @@ class BiometricWebSocketController(
     private val leaderboardRedisService: LeaderboardRedisService,
     private val hordePositionService: HordePositionService,
     private val messagingTemplate: SimpMessagingTemplate,
-    private val validator: Validator
+    private val validator: Validator,
+    private val biometricPersistenceService: BiometricPersistenceService
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -60,6 +57,9 @@ class BiometricWebSocketController(
 
         val start = System.currentTimeMillis()
 
+        // Persiste no PostgreSQL de forma assíncrona — não bloqueia o handler
+        biometricPersistenceService.persistAsync(message)
+
         sessionRedisService.saveUserState(message.sessionId, message.userId, message)
         leaderboardRedisService.updateUserDistance(message.sessionId, message.userId, message.accumulatedDistance)
 
@@ -72,6 +72,15 @@ class BiometricWebSocketController(
                     distanceKm = tuple.score ?: 0.0
                 )
             } ?: emptyList()
+
+        // Horda adaptativa: atualiza o pace no Redis com a média dos usuários ativos
+        if (leaderboardRedisService.isHordeAdaptive(message.sessionId) && entries.isNotEmpty()) {
+            val activeUserIds = entries.map { it.userId }
+            val avgPace = sessionRedisService.getAveragePace(message.sessionId, activeUserIds)
+            if (avgPace != null && avgPace > 0) {
+                leaderboardRedisService.updateHordePace(message.sessionId, avgPace)
+            }
+        }
 
         val startEpoch = leaderboardRedisService.getSessionStartEpoch(message.sessionId)
         val hordePace = leaderboardRedisService.getHordePace(message.sessionId)

--- a/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
@@ -4,6 +4,7 @@ import br.inatel.tcc.dto.BiometricDataMessage
 import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.dto.LeaderboardResponse
 import br.inatel.tcc.service.BiometricPersistenceService
+import br.inatel.tcc.service.CardiacZoneService
 import br.inatel.tcc.service.HordePositionService
 import br.inatel.tcc.service.redis.LeaderboardRedisService
 import br.inatel.tcc.service.redis.SessionRedisService
@@ -26,11 +27,6 @@ import io.swagger.v3.oas.annotations.tags.Tag
  * Canal de saída:    /topic/session/{sessionId}/leaderboard  (broadcast para todos na sessão)
  *
  * Cada operação Redis neste handler leva < 1ms → latência total do handler < 10ms.
- *
- * TODO [FASE 4 - ZONA CARDÍACA]: Após calcular a zona cardíaca (CardiacZone.kt),
- *   incluí-la no LeaderboardResponse para que o app exiba o ícone de intensidade
- *   de cada competidor em tempo real.
- *   Referência: domain/biometricdata/CardiacZone.kt
  */
 @Controller
 @Tag(name = "Biometric Data", description = "Biometric Data API")
@@ -40,7 +36,8 @@ class BiometricWebSocketController(
     private val hordePositionService: HordePositionService,
     private val messagingTemplate: SimpMessagingTemplate,
     private val validator: Validator,
-    private val biometricPersistenceService: BiometricPersistenceService
+    private val biometricPersistenceService: BiometricPersistenceService,
+    private val cardiacZoneService: CardiacZoneService
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -60,18 +57,28 @@ class BiometricWebSocketController(
         // Persiste no PostgreSQL de forma assíncrona — não bloqueia o handler
         biometricPersistenceService.persistAsync(message)
 
-        sessionRedisService.saveUserState(message.sessionId, message.userId, message)
+        // Zona cardíaca: cache hit em Redis (sem DB), null se maxHeartRate não configurado
+        val maxHr = cardiacZoneService.getOrCacheMaxHr(message.sessionId, message.userId)
+        val zone = if (maxHr != null) cardiacZoneService.calculate(message.bpm, maxHr) else null
+
+        sessionRedisService.saveUserState(message.sessionId, message.userId, message, zone)
         leaderboardRedisService.updateUserDistance(message.sessionId, message.userId, message.accumulatedDistance)
 
         val userRank = (leaderboardRedisService.getUserRank(message.sessionId, message.userId) ?: 0L) + 1
-        val entries = leaderboardRedisService.getTopEntries(message.sessionId, 10)
-            ?.mapIndexed { index, tuple ->
-                LeaderboardEntryDto(
-                    userId = tuple.value ?: "",
-                    rank = index + 1,
-                    distanceKm = tuple.score ?: 0.0
-                )
-            } ?: emptyList()
+        val topTuples = leaderboardRedisService.getTopEntries(message.sessionId, 10)?.toList() ?: emptyList()
+        val topUserIds = topTuples.map { it.value ?: "" }
+
+        // Zona cardíaca de cada competidor no top-10 (lida do HASH Redis)
+        val cardiacZones = sessionRedisService.getCardiacZones(message.sessionId, topUserIds)
+        val entries = topTuples.mapIndexed { index, tuple ->
+            val entryUserId = tuple.value ?: ""
+            LeaderboardEntryDto(
+                userId = entryUserId,
+                rank = index + 1,
+                distanceKm = tuple.score ?: 0.0,
+                cardiacZone = cardiacZones[entryUserId]
+            )
+        }
 
         // Horda adaptativa: atualiza o pace no Redis com a média dos usuários ativos
         if (leaderboardRedisService.isHordeAdaptive(message.sessionId) && entries.isNotEmpty()) {
@@ -90,18 +97,23 @@ class BiometricWebSocketController(
             null
         }
 
+        val isBehindHorde = hordeVirtualDistance?.let { message.accumulatedDistance < it }
+        val distanceToHorde = hordeVirtualDistance?.let { it - message.accumulatedDistance }
+
         val response = LeaderboardResponse(
             sessionId = message.sessionId,
             userRank = userRank.toInt(),
             hordeVirtualDistanceKm = hordeVirtualDistance,
-            entries = entries
+            entries = entries,
+            isBehindHorde = isBehindHorde,
+            distanceToHorde = distanceToHorde
         )
         messagingTemplate.convertAndSend("/topic/session/${message.sessionId}/leaderboard", response)
 
         val elapsed = System.currentTimeMillis() - start
         log.info(
-            "[BIOMETRIA] sessionId={} userId={} bpm={} distance={}km rank={} horde={}km redis={}ms",
-            message.sessionId, message.userId, message.bpm,
+            "[BIOMETRIA] sessionId={} userId={} bpm={} zone={} distance={}km rank={} horde={}km redis={}ms",
+            message.sessionId, message.userId, message.bpm, zone,
             message.accumulatedDistance, userRank, hordeVirtualDistance, elapsed
         )
     }

--- a/src/main/kotlin/br/inatel/tcc/controller/TrainSessionController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/TrainSessionController.kt
@@ -1,5 +1,6 @@
 package br.inatel.tcc.controller
 
+import br.inatel.tcc.dto.HordeResponse
 import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.dto.StartSessionResponse
@@ -65,5 +66,14 @@ class TrainSessionController(
     ): ResponseEntity<TrainSession> {
         val session = trainSessionService.getSession(sessionId)
         return ResponseEntity.ok(session)
+    }
+
+    @Operation(summary = "List all hordes", responses = [ApiResponse(description = "List of hordes", content = [Content(mediaType = "application/json", schema = Schema(implementation = HordeResponse::class))])])
+    @GetMapping(value = ["/hordes"])
+    fun getHordes(
+        authentication: Authentication
+    ): ResponseEntity<List<HordeResponse>> {
+        val hordes = trainSessionService.getAllHordes()
+        return ResponseEntity.ok(hordes)
     }
 }

--- a/src/main/kotlin/br/inatel/tcc/domain/horde/Horde.kt
+++ b/src/main/kotlin/br/inatel/tcc/domain/horde/Horde.kt
@@ -24,6 +24,9 @@ class Horde(
 
     val targetPace: Double? = null,
 
+    @Column(nullable = false)
+    val isAdaptive: Boolean = false,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "horde_id", nullable = true)
     val parentHorde: Horde? = null

--- a/src/main/kotlin/br/inatel/tcc/domain/trainsession/TrainSessionRepository.kt
+++ b/src/main/kotlin/br/inatel/tcc/domain/trainsession/TrainSessionRepository.kt
@@ -6,4 +6,5 @@ import java.util.UUID
 interface TrainSessionRepository : JpaRepository<TrainSession, UUID> {
     fun findByUserId(userId: UUID): List<TrainSession>
     fun findByUserIdAndHordeId(userId: UUID, hordeId: UUID): List<TrainSession>
+    fun countByUser_IdAndEndDateIsNotNull(userId: UUID): Long
 }

--- a/src/main/kotlin/br/inatel/tcc/domain/userachievement/UserAchievementRepository.kt
+++ b/src/main/kotlin/br/inatel/tcc/domain/userachievement/UserAchievementRepository.kt
@@ -6,4 +6,5 @@ import java.util.UUID
 interface UserAchievementRepository : JpaRepository<UserAchievement, UserAchievementId> {
     fun findByUserId(userId: UUID): List<UserAchievement>
     fun findByAchievementId(achievementId: UUID): List<UserAchievement>
+    fun existsByIdUserIdAndIdAchievementId(userId: UUID, achievementId: UUID): Boolean
 }

--- a/src/main/kotlin/br/inatel/tcc/dto/HordeResponse.kt
+++ b/src/main/kotlin/br/inatel/tcc/dto/HordeResponse.kt
@@ -1,0 +1,13 @@
+package br.inatel.tcc.dto
+
+import br.inatel.tcc.domain.horde.HordeDifficulty
+import java.util.UUID
+
+data class HordeResponse(
+    val id: UUID?,
+    val name: String,
+    val description: String?,
+    val difficulty: HordeDifficulty,
+    val estimatedDuration: Int,
+    val targetPace: Double?
+)

--- a/src/main/kotlin/br/inatel/tcc/dto/LeaderboardEntryDto.kt
+++ b/src/main/kotlin/br/inatel/tcc/dto/LeaderboardEntryDto.kt
@@ -1,14 +1,14 @@
 package br.inatel.tcc.dto
 
+import br.inatel.tcc.domain.biometricdata.CardiacZone
+
 /**
  * Representa a entrada de um usuário no leaderboard da sessão.
- * Populado a partir do ZSET Redis (ZREVRANGE WITHSCORES).
- *
- * TODO [FASE 4 - ZONA CARDÍACA]: Adicionar campo cardiacZone (CardiacZone enum)
- * para exibir a zona de esforço de cada competidor em tempo real no app.
+ * Populado a partir do ZSET Redis (ZREVRANGE WITHSCORES) e do HASH de estado biométrico.
  */
 data class LeaderboardEntryDto(
     val userId: String,
     val rank: Int,
-    val distanceKm: Double
+    val distanceKm: Double,
+    val cardiacZone: CardiacZone? = null  // null quando usuário não tem maxHeartRate configurado
 )

--- a/src/main/kotlin/br/inatel/tcc/dto/LeaderboardResponse.kt
+++ b/src/main/kotlin/br/inatel/tcc/dto/LeaderboardResponse.kt
@@ -5,14 +5,14 @@ package br.inatel.tcc.dto
  * /topic/session/{sessionId}/leaderboard após cada update de biometria.
  *
  * O app React Native usa esse payload para atualizar a UI de corrida em tempo real.
- *
- * TODO [FASE 4 - AMIGOS]: Adicionar campo isBehindHorde (Boolean) e
- * distanceToHorde (Double) para facilitar a exibição no mapa do app.
  */
 data class LeaderboardResponse(
     val sessionId: String,
     val userRank: Int,
     // null quando a sessão não está associada a uma Horda (treino livre)
     val hordeVirtualDistanceKm: Double?,
-    val entries: List<LeaderboardEntryDto>
+    val entries: List<LeaderboardEntryDto>,
+    // null quando não há horda; negativo = usuário à frente da horda
+    val isBehindHorde: Boolean? = null,
+    val distanceToHorde: Double? = null
 )

--- a/src/main/kotlin/br/inatel/tcc/dto/SessionResultNotification.kt
+++ b/src/main/kotlin/br/inatel/tcc/dto/SessionResultNotification.kt
@@ -1,0 +1,18 @@
+package br.inatel.tcc.dto
+
+/**
+ * Notificação enviada via WebSocket para amigos de um usuário quando sua sessão encerra.
+ *
+ * Canal: /topic/user/{friendId}/notifications
+ *
+ * O app React Native subscreve ao canal do próprio usuário para receber
+ * atualizações em tempo real sobre atividades dos amigos.
+ */
+data class SessionResultNotification(
+    val type: String = "SESSION_ENDED",
+    val userId: String,
+    val userName: String,
+    val sessionId: String,
+    val totalDistanceKm: Double?,
+    val rank: Int?
+)

--- a/src/main/kotlin/br/inatel/tcc/dto/UserResponseDto.kt
+++ b/src/main/kotlin/br/inatel/tcc/dto/UserResponseDto.kt
@@ -9,6 +9,11 @@ data class UserResponseDto(
     val name: String,
     val birthdayDate: LocalDate?,
     val maxHeartRate: Int?,
-    val height: Double?,
-    val weight: Double?
-)
+    var height: Double?,
+    var weight: Double?
+) {
+    init {
+        height = height?.let { Math.round(it * 100) / 100.0 }
+        weight = weight?.let { Math.round(it * 100) / 100.0 }
+    }
+}

--- a/src/main/kotlin/br/inatel/tcc/service/AchievementService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/AchievementService.kt
@@ -1,0 +1,92 @@
+package br.inatel.tcc.service
+
+import br.inatel.tcc.domain.achievement.AchievementRepository
+import br.inatel.tcc.domain.trainsession.TrainSession
+import br.inatel.tcc.domain.trainsession.TrainSessionRepository
+import br.inatel.tcc.domain.user.User
+import br.inatel.tcc.domain.userachievement.UserAchievement
+import br.inatel.tcc.domain.userachievement.UserAchievementId
+import br.inatel.tcc.domain.userachievement.UserAchievementRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.ZSetOperations
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Verifica e concede conquistas ao usuário ao encerrar uma sessão de treino.
+ *
+ * Critérios suportados (campo Achievement.criterion):
+ *   FIRST_RUN    — primeira sessão completada pelo usuário
+ *   DISTANCE_5KM — correu ≥ 5km na sessão
+ *   HORDE_TOP_1  — terminou em 1º lugar com horda ativa
+ *
+ * Apenas achievements com active=true são avaliados.
+ * Achievements já concedidos anteriormente são ignorados (idempotente).
+ */
+@Service
+class AchievementService(
+    private val achievementRepository: AchievementRepository,
+    private val userAchievementRepository: UserAchievementRepository,
+    private val trainSessionRepository: TrainSessionRepository
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun verifyAndGrant(
+        user: User,
+        session: TrainSession,
+        finalLeaderboard: Set<ZSetOperations.TypedTuple<String>>?
+    ) {
+        val activeAchievements = achievementRepository.findByActive(true)
+        if (activeAchievements.isEmpty()) return
+
+        for (achievement in activeAchievements) {
+            val achievementId = achievement.id ?: continue
+            val userId = user.id ?: continue
+
+            if (userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievementId)) continue
+
+            val shouldGrant = when (achievement.criterion) {
+                "FIRST_RUN"    -> isFirstRun(user)
+                "DISTANCE_5KM" -> hasRunFiveKm(user, finalLeaderboard)
+                "HORDE_TOP_1"  -> isHordeTopOne(user, session, finalLeaderboard)
+                else           -> false
+            }
+
+            if (shouldGrant) {
+                userAchievementRepository.save(
+                    UserAchievement(
+                        id = UserAchievementId(userId = userId, achievementId = achievementId),
+                        user = user,
+                        achievement = achievement
+                    )
+                )
+                log.info("[ACHIEVEMENT] Conquista '{}' concedida ao usuário {}", achievement.title, user.email)
+            }
+        }
+    }
+
+    /** Verifica se esta foi a primeira sessão completada do usuário. */
+    private fun isFirstRun(user: User): Boolean =
+        trainSessionRepository.countByUser_IdAndEndDateIsNotNull(user.id!!) == 1L
+
+    /** Verifica se o usuário percorreu pelo menos 5km nesta sessão. */
+    private fun hasRunFiveKm(user: User, leaderboard: Set<ZSetOperations.TypedTuple<String>>?): Boolean {
+        val distance = leaderboard
+            ?.firstOrNull { it.value == user.id.toString() }
+            ?.score ?: 0.0
+        return distance >= 5.0
+    }
+
+    /** Verifica se o usuário terminou em 1º lugar em uma sessão com horda. */
+    private fun isHordeTopOne(
+        user: User,
+        session: TrainSession,
+        leaderboard: Set<ZSetOperations.TypedTuple<String>>?
+    ): Boolean {
+        if (session.horde == null) return false
+        val topEntry = leaderboard?.firstOrNull() ?: return false
+        return topEntry.value == user.id.toString()
+    }
+}

--- a/src/main/kotlin/br/inatel/tcc/service/BiometricPersistenceService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/BiometricPersistenceService.kt
@@ -1,0 +1,56 @@
+package br.inatel.tcc.service
+
+import br.inatel.tcc.domain.biometricdata.BiometricData
+import br.inatel.tcc.domain.biometricdata.BiometricDataRepository
+import br.inatel.tcc.domain.trainsession.TrainSessionRepository
+import br.inatel.tcc.dto.BiometricDataMessage
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Persiste dados biométricos no PostgreSQL de forma assíncrona,
+ * sem bloquear o fluxo do WebSocket handler (< 10ms target).
+ *
+ * Cada chamada a persistAsync() é executada em thread separada do pool de async do Spring.
+ * A TrainSession é buscada dentro do método assíncrono para garantir contexto JPA válido.
+ */
+@Service
+class BiometricPersistenceService(
+    private val biometricDataRepository: BiometricDataRepository,
+    private val trainSessionRepository: TrainSessionRepository
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Async
+    @Transactional
+    fun persistAsync(message: BiometricDataMessage) {
+        val sessionId = runCatching { UUID.fromString(message.sessionId) }.getOrNull() ?: return
+
+        val session = trainSessionRepository.findById(sessionId).orElse(null)
+        if (session == null) {
+            log.warn("[BIOMETRIA-ASYNC] Sessão não encontrada para persistência: {}", message.sessionId)
+            return
+        }
+
+        biometricDataRepository.save(
+            BiometricData(
+                timestamp = Instant.ofEpochMilli(message.timestamp)
+                    .atZone(ZoneOffset.UTC)
+                    .toLocalDateTime(),
+                bpm = message.bpm,
+                cadence = message.cadence,
+                speed = message.speed,
+                pace = message.pace,
+                accumulatedDistance = message.accumulatedDistance,
+                accumulatedCalories = message.accumulatedCalories,
+                trainSession = session
+            )
+        )
+    }
+}

--- a/src/main/kotlin/br/inatel/tcc/service/CardiacZoneService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/CardiacZoneService.kt
@@ -1,0 +1,68 @@
+package br.inatel.tcc.service
+
+import br.inatel.tcc.domain.biometricdata.CardiacZone
+import br.inatel.tcc.domain.user.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.util.UUID
+
+/**
+ * Calcula a zona cardíaca do usuário com base no BPM atual e no FC máximo (maxHeartRate).
+ *
+ * O maxHeartRate é buscado do PostgreSQL na primeira mensagem de cada usuário por sessão
+ * e cacheado em Redis (TTL 24h) para evitar query a cada update de biometria.
+ *
+ * Zonas (% do FC máximo):
+ *   ZONE_1 → < 60%  (repouso / recuperação ativa)
+ *   ZONE_2 → 60-70% (queima de gordura)
+ *   ZONE_3 → 70-80% (aeróbico)
+ *   ZONE_4 → 80-90% (anaeróbico)
+ *   ZONE_5 → ≥ 90%  (máximo / VO2 max)
+ */
+@Service
+class CardiacZoneService(
+    private val userRepository: UserRepository,
+    private val redis: StringRedisTemplate
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private fun maxHrKey(sessionId: String, userId: String) = "session:$sessionId:user:$userId:maxhr"
+
+    /**
+     * Retorna o FC máximo do usuário, usando Redis como cache.
+     * Na primeira chamada por sessão/usuário: consulta o PostgreSQL e armazena o resultado.
+     *
+     * @return maxHeartRate do usuário, ou null se não cadastrado ou userId inválido
+     */
+    fun getOrCacheMaxHr(sessionId: String, userId: String): Int? {
+        val key = maxHrKey(sessionId, userId)
+        val cached = redis.opsForValue().get(key)
+        if (cached != null) return cached.toIntOrNull()
+
+        val userUuid = runCatching { UUID.fromString(userId) }.getOrNull() ?: return null
+        val maxHr = userRepository.findById(userUuid).orElse(null)?.maxHeartRate
+        if (maxHr == null) {
+            log.debug("[CARDIAC] maxHeartRate não definido para userId={}", userId)
+            return null
+        }
+        redis.opsForValue().set(key, maxHr.toString(), Duration.ofHours(24))
+        return maxHr
+    }
+
+    /**
+     * Calcula a zona cardíaca com base no BPM atual e no FC máximo.
+     */
+    fun calculate(bpm: Int, maxHr: Int): CardiacZone {
+        val pct = bpm.toDouble() / maxHr
+        return when {
+            pct < 0.60 -> CardiacZone.ZONE_1
+            pct < 0.70 -> CardiacZone.ZONE_2
+            pct < 0.80 -> CardiacZone.ZONE_3
+            pct < 0.90 -> CardiacZone.ZONE_4
+            else        -> CardiacZone.ZONE_5
+        }
+    }
+}

--- a/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
@@ -29,10 +29,6 @@ import java.util.UUID
  *   Durante a corrida → apenas Redis (< 1ms por operação)
  *   Ao encerrar       → flush para PostgreSQL (rankings + sessão)
  *
- * TODO [FASE 3 - ACHIEVEMENTS]: Após persistir o ranking, verificar critérios de conquistas
- *   (ex: primeira corrida completada, 5km, top 1 na Horda) e registrar em UserAchievement.
- *   Referência: domain/userachievement/UserAchievement.kt + domain/achievement/Achievement.kt
- *
  * TODO [FASE 4 - AMIGOS]: Ao encerrar, notificar amigos do usuário via WebSocket
  *   sobre o resultado da sessão.
  *   Referência: domain/friendship/FriendshipRepository.kt
@@ -47,7 +43,8 @@ class TrainSessionService(
     private val hordeRepository: HordeRepository,
     private val rankingRepository: RankingRepository,
     private val leaderboardRedisService: LeaderboardRedisService,
-    private val hordePositionService: HordePositionService
+    private val hordePositionService: HordePositionService,
+    private val achievementService: AchievementService
 ) {
 
     @Transactional
@@ -74,7 +71,11 @@ class TrainSessionService(
 
         val sessionId = session.id.toString()
 
-        leaderboardRedisService.initSession(sessionId, horde?.let { hordePositionService.resolveEffectivePace(it) })
+        leaderboardRedisService.initSession(
+            sessionId,
+            horde?.let { hordePositionService.resolveEffectivePace(it) },
+            horde?.isAdaptive ?: false
+        )
 
         return StartSessionResponse(sessionId = sessionId)
     }
@@ -108,7 +109,7 @@ class TrainSessionService(
             ?.firstOrNull { it.value == session.user.id.toString() }
             ?.score
 
-        trainSessionRepository.save(
+        val updatedSession = trainSessionRepository.save(
             TrainSession(
                 id = session.id,
                 user = session.user,
@@ -123,6 +124,8 @@ class TrainSessionService(
         )
 
         leaderboardRedisService.expireSessionKeys(sessionId)
+
+        achievementService.verifyAndGrant(session.user, updatedSession, finalLeaderboard)
     }
 
     fun getLeaderboard(sessionId: String): List<LeaderboardEntryDto> {

--- a/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
@@ -1,17 +1,23 @@
 package br.inatel.tcc.service
 
+import br.inatel.tcc.domain.friendship.FriendshipRepository
+import br.inatel.tcc.domain.friendship.FriendshipStatus
 import br.inatel.tcc.domain.ranking.Ranking
 import br.inatel.tcc.domain.ranking.RankingRepository
 import br.inatel.tcc.domain.trainsession.TrainSession
 import br.inatel.tcc.domain.trainsession.TrainSessionRepository
 import br.inatel.tcc.domain.trainsession.TrainType
 import br.inatel.tcc.domain.horde.HordeRepository
+import br.inatel.tcc.domain.user.User
 import br.inatel.tcc.domain.user.UserRepository
 import br.inatel.tcc.dto.HordeResponse
 import br.inatel.tcc.dto.LeaderboardEntryDto
+import br.inatel.tcc.dto.SessionResultNotification
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.dto.StartSessionResponse
 import br.inatel.tcc.service.redis.LeaderboardRedisService
+import org.springframework.data.redis.core.ZSetOperations
+import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -30,10 +36,6 @@ import java.util.UUID
  *   Durante a corrida → apenas Redis (< 1ms por operação)
  *   Ao encerrar       → flush para PostgreSQL (rankings + sessão)
  *
- * TODO [FASE 4 - AMIGOS]: Ao encerrar, notificar amigos do usuário via WebSocket
- *   sobre o resultado da sessão.
- *   Referência: domain/friendship/FriendshipRepository.kt
- *
  * TODO [FASE 5 - CHECKPOINTS]: Implementar flush incremental no PostgreSQL a cada 5 minutos
  *   como checkpoint (caso o app feche inesperadamente e a sessão não seja encerrada).
  */
@@ -45,7 +47,9 @@ class TrainSessionService(
     private val rankingRepository: RankingRepository,
     private val leaderboardRedisService: LeaderboardRedisService,
     private val hordePositionService: HordePositionService,
-    private val achievementService: AchievementService
+    private val achievementService: AchievementService,
+    private val friendshipRepository: FriendshipRepository,
+    private val messagingTemplate: SimpMessagingTemplate
 ) {
 
     @Transactional
@@ -127,6 +131,40 @@ class TrainSessionService(
         leaderboardRedisService.expireSessionKeys(sessionId)
 
         achievementService.verifyAndGrant(session.user, updatedSession, finalLeaderboard)
+        notifyFriends(session.user, updatedSession, finalLeaderboard)
+    }
+
+    private fun notifyFriends(
+        user: User,
+        session: TrainSession,
+        finalLeaderboard: Set<ZSetOperations.TypedTuple<String>>?
+    ) {
+        val userId = user.id ?: return
+        val friendships = friendshipRepository.findByRequesterIdOrRecipientId(userId, userId)
+            .filter { it.status == FriendshipStatus.ACCEPTED }
+        if (friendships.isEmpty()) return
+
+        val userRank = finalLeaderboard
+            ?.indexOfFirst { it.value == userId.toString() }
+            ?.takeIf { it >= 0 }
+            ?.plus(1)
+
+        val notification = SessionResultNotification(
+            userId = userId.toString(),
+            userName = user.name,
+            sessionId = session.id.toString(),
+            totalDistanceKm = session.totalDistance,
+            rank = userRank
+        )
+
+        for (friendship in friendships) {
+            val friendId = if (friendship.requester.id == userId) {
+                friendship.recipient.id
+            } else {
+                friendship.requester.id
+            } ?: continue
+            messagingTemplate.convertAndSend("/topic/user/$friendId/notifications", notification)
+        }
     }
 
     fun getLeaderboard(sessionId: String): List<LeaderboardEntryDto> {

--- a/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
@@ -7,6 +7,7 @@ import br.inatel.tcc.domain.trainsession.TrainSessionRepository
 import br.inatel.tcc.domain.trainsession.TrainType
 import br.inatel.tcc.domain.horde.HordeRepository
 import br.inatel.tcc.domain.user.UserRepository
+import br.inatel.tcc.dto.HordeResponse
 import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.dto.StartSessionResponse
@@ -139,5 +140,18 @@ class TrainSessionService(
         val id = UUID.fromString(sessionId)
         return trainSessionRepository.findById(id)
             .orElseThrow { IllegalArgumentException("Sessão não encontrada: $sessionId") }
+    }
+
+    fun getAllHordes(): List<HordeResponse> {
+        return hordeRepository.findAll().map { horde ->
+            HordeResponse(
+                id = horde.id,
+                name = horde.name,
+                description = horde.description,
+                difficulty = horde.difficulty,
+                estimatedDuration = horde.estimatedDuration,
+                targetPace = horde.targetPace
+            )
+        }
     }
 }

--- a/src/main/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisService.kt
@@ -9,9 +9,10 @@ import java.time.Duration
  * Gerencia o leaderboard da sessão de treino no Redis usando Sorted Sets (ZSET).
  *
  * Estrutura de keys Redis:
- *   session:{sessionId}:leaderboard  → ZSET  member=userId, score=distânciaKm
- *   session:{sessionId}:start        → STRING época em segundos do início da sessão
- *   session:{sessionId}:horde:pace   → STRING targetPace da Horda em min/km (opcional)
+ *   session:{sessionId}:leaderboard    → ZSET  member=userId, score=distânciaKm
+ *   session:{sessionId}:start          → STRING época em segundos do início da sessão
+ *   session:{sessionId}:horde:pace     → STRING targetPace da Horda em min/km (opcional)
+ *   session:{sessionId}:horde:adaptive → STRING "true" se horda é adaptativa (opcional)
  *
  * Por que ZSET para o leaderboard?
  *   - ZADD é O(log N) — atualiza posição e reordena em uma única operação
@@ -30,6 +31,7 @@ class LeaderboardRedisService(
     private fun leaderboardKey(sessionId: String) = "session:$sessionId:leaderboard"
     private fun startKey(sessionId: String) = "session:$sessionId:start"
     private fun hordeKey(sessionId: String) = "session:$sessionId:horde:pace"
+    private fun hordeAdaptiveKey(sessionId: String) = "session:$sessionId:horde:adaptive"
 
     /**
      * Inicializa os metadados da sessão no Redis.
@@ -37,7 +39,7 @@ class LeaderboardRedisService(
      *
      * Usa verificação de existência para ser idempotente — reconexões não sobrescrevem o start.
      */
-    fun initSession(sessionId: String, targetPaceMinPerKm: Double?) {
+    fun initSession(sessionId: String, targetPaceMinPerKm: Double?, isAdaptive: Boolean = false) {
         val startKey = startKey(sessionId)
         if (redis.hasKey(startKey) != true) {
             val epochSeconds = System.currentTimeMillis() / 1000
@@ -47,7 +49,23 @@ class LeaderboardRedisService(
             targetPaceMinPerKm?.let {
                 redis.opsForValue().set(hordeKey(sessionId), it.toString(), Duration.ofHours(24))
             }
+
+            if (isAdaptive) {
+                redis.opsForValue().set(hordeAdaptiveKey(sessionId), "true", Duration.ofHours(24))
+            }
         }
+    }
+
+    /** Retorna true se a horda desta sessão está em modo adaptativo. */
+    fun isHordeAdaptive(sessionId: String): Boolean =
+        redis.opsForValue().get(hordeAdaptiveKey(sessionId)) == "true"
+
+    /**
+     * Atualiza o pace da horda no Redis.
+     * Usado pelo modo adaptativo para refletir a performance média atual dos usuários.
+     */
+    fun updateHordePace(sessionId: String, pace: Double) {
+        redis.opsForValue().set(hordeKey(sessionId), pace.toString(), Duration.ofHours(24))
     }
 
     /**
@@ -93,5 +111,6 @@ class LeaderboardRedisService(
         redis.expire(leaderboardKey(sessionId), ttl)
         redis.expire(startKey(sessionId), ttl)
         redis.expire(hordeKey(sessionId), ttl)
+        redis.expire(hordeAdaptiveKey(sessionId), ttl)
     }
 }

--- a/src/main/kotlin/br/inatel/tcc/service/redis/SessionRedisService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/redis/SessionRedisService.kt
@@ -1,5 +1,6 @@
 package br.inatel.tcc.service.redis
 
+import br.inatel.tcc.domain.biometricdata.CardiacZone
 import br.inatel.tcc.dto.BiometricDataMessage
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
@@ -17,10 +18,6 @@ import java.time.Duration
  *   - HMSET atualiza campos individuais sem reescrever o objeto inteiro
  *   - Permite leituras parciais (HGET "bpm") para dashboards específicos
  *
- * TODO [FASE 4 - ZONA CARDÍACA]: Calcular e armazenar cardiacZone neste HASH
- *   com base no bpm recebido e no User.maxHeartRate (buscar do PostgreSQL no initSession
- *   e cachear em Redis para evitar query a cada update).
- *   Referência: domain/biometricdata/CardiacZone.kt
  */
 @Service
 class SessionRedisService(
@@ -30,9 +27,9 @@ class SessionRedisService(
     private fun userKey(sessionId: String, userId: String) = "session:$sessionId:user:$userId"
 
     /** Salva ou atualiza o estado biométrico atual do usuário (HMSET). */
-    fun saveUserState(sessionId: String, userId: String, message: BiometricDataMessage) {
+    fun saveUserState(sessionId: String, userId: String, message: BiometricDataMessage, cardiacZone: CardiacZone? = null) {
         val key = userKey(sessionId, userId)
-        val fields = mapOf(
+        val fields = mutableMapOf(
             "bpm"       to message.bpm.toString(),
             "speed"     to message.speed.toString(),
             "pace"      to message.pace.toString(),
@@ -41,9 +38,20 @@ class SessionRedisService(
             "calories"  to message.accumulatedCalories.toString(),
             "timestamp" to message.timestamp.toString()
         )
+        cardiacZone?.let { fields["cardiacZone"] = it.name }
         redis.opsForHash<String, String>().putAll(key, fields)
         redis.expire(key, Duration.ofHours(24))
     }
+
+    /**
+     * Retorna o mapa de userId → CardiacZone para os usuários fornecidos.
+     * Lê o campo "cardiacZone" do HASH de cada usuário.
+     */
+    fun getCardiacZones(sessionId: String, userIds: List<String>): Map<String, CardiacZone?> =
+        userIds.associateWith { userId ->
+            getUserState(sessionId, userId)["cardiacZone"]
+                ?.let { runCatching { CardiacZone.valueOf(it) }.getOrNull() }
+        }
 
     /** Lê o último estado biométrico do usuário na sessão. */
     fun getUserState(sessionId: String, userId: String): Map<String, String> {

--- a/src/main/kotlin/br/inatel/tcc/service/redis/SessionRedisService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/redis/SessionRedisService.kt
@@ -55,4 +55,18 @@ class SessionRedisService(
     fun expireUserKey(sessionId: String, userId: String) {
         redis.expire(userKey(sessionId, userId), Duration.ofHours(1))
     }
+
+    /**
+     * Calcula o pace médio dos usuários ativos na sessão.
+     * Usado pelo modo adaptativo de horda para atualizar o pace em tempo real.
+     *
+     * @param userIds Lista de userIds ativos (obtida do leaderboard ZSET)
+     * @return Média do pace em min/km, ou null se nenhum usuário tiver pace válido
+     */
+    fun getAveragePace(sessionId: String, userIds: List<String>): Double? {
+        val paces = userIds.mapNotNull { userId ->
+            getUserState(sessionId, userId)["pace"]?.toDoubleOrNull()
+        }.filter { it > 0 }
+        return if (paces.isEmpty()) null else paces.average()
+    }
 }

--- a/src/main/resources/db/migration/V3__add_adaptive_horde.sql
+++ b/src/main/resources/db/migration/V3__add_adaptive_horde.sql
@@ -1,0 +1,3 @@
+-- V3: Suporte a horda adaptativa
+-- Permite que uma horda ajuste seu pace dinamicamente à performance média dos usuários.
+ALTER TABLE hordes ADD COLUMN is_adaptive BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
@@ -2,6 +2,7 @@ package br.inatel.tcc.controller
 
 import br.inatel.tcc.dto.BiometricDataMessage
 import br.inatel.tcc.dto.LeaderboardEntryDto
+import br.inatel.tcc.service.BiometricPersistenceService
 import br.inatel.tcc.service.HordePositionService
 import br.inatel.tcc.service.redis.LeaderboardRedisService
 import br.inatel.tcc.service.redis.SessionRedisService
@@ -31,6 +32,7 @@ class BiometricWebSocketControllerTest {
     @Mock private lateinit var hordePositionService: HordePositionService
     @Mock private lateinit var messagingTemplate: SimpMessagingTemplate
     @Mock private lateinit var validator: Validator
+    @Mock private lateinit var biometricPersistenceService: BiometricPersistenceService
 
     @InjectMocks private lateinit var controller: BiometricWebSocketController
 
@@ -178,6 +180,32 @@ class BiometricWebSocketControllerTest {
 
         verify(messagingTemplate).convertAndSend(any<String>(), captor.capture())
         assert(captor.firstValue.userRank == 1)
+    }
+
+    @Test
+    fun shouldUpdateHordePace_whenHordeIsAdaptive() {
+        val message = buildMessage()
+        setupLeaderboardMocks(rank = 0L)
+        whenever(leaderboardRedisService.isHordeAdaptive(sessionId)).thenReturn(true)
+        whenever(leaderboardRedisService.getTopEntries(sessionId, 10)).thenReturn(
+            linkedSetOf(org.springframework.data.redis.core.DefaultTypedTuple(userId, 2.5))
+        )
+        whenever(sessionRedisService.getAveragePace(sessionId, listOf(userId))).thenReturn(5.5)
+
+        controller.receiveBiometricData(message)
+
+        verify(leaderboardRedisService).updateHordePace(sessionId, 5.5)
+    }
+
+    @Test
+    fun shouldNotUpdateHordePace_whenHordeIsNotAdaptive() {
+        val message = buildMessage()
+        setupLeaderboardMocks(rank = 0L)
+        whenever(leaderboardRedisService.isHordeAdaptive(sessionId)).thenReturn(false)
+
+        controller.receiveBiometricData(message)
+
+        verify(leaderboardRedisService, never()).updateHordePace(any(), any())
     }
 
     @Test

--- a/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
@@ -3,6 +3,7 @@ package br.inatel.tcc.controller
 import br.inatel.tcc.dto.BiometricDataMessage
 import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.service.BiometricPersistenceService
+import br.inatel.tcc.service.CardiacZoneService
 import br.inatel.tcc.service.HordePositionService
 import br.inatel.tcc.service.redis.LeaderboardRedisService
 import br.inatel.tcc.service.redis.SessionRedisService
@@ -33,6 +34,7 @@ class BiometricWebSocketControllerTest {
     @Mock private lateinit var messagingTemplate: SimpMessagingTemplate
     @Mock private lateinit var validator: Validator
     @Mock private lateinit var biometricPersistenceService: BiometricPersistenceService
+    @Mock private lateinit var cardiacZoneService: CardiacZoneService
 
     @InjectMocks private lateinit var controller: BiometricWebSocketController
 

--- a/src/test/kotlin/br/inatel/tcc/controller/TrainSessionControllerTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/controller/TrainSessionControllerTest.kt
@@ -3,6 +3,7 @@ package br.inatel.tcc.controller
 import br.inatel.tcc.domain.trainsession.TrainSession
 import br.inatel.tcc.domain.trainsession.TrainType
 import br.inatel.tcc.domain.user.User
+import br.inatel.tcc.dto.HordeResponse
 import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.dto.StartSessionResponse
@@ -152,6 +153,24 @@ class TrainSessionControllerTest {
         assertThrows(IllegalArgumentException::class.java) {
             controller.getSession(sessionId.toString(), principal)
         }
+    }
+
+    // ─── GET /sessions/hordes ─────────────────────────────────────────────────
+
+    @Test
+    fun getHordes_shouldReturn200WithHordes() {
+        val principal = mockAuthentication("user@example.com")
+        val hordes = listOf(
+            HordeResponse(id = UUID.randomUUID(), name = "Horde 1", description = "Desc 1", difficulty = br.inatel.tcc.domain.horde.HordeDifficulty.EASY, estimatedDuration = 30, targetPace = 5.0)
+        )
+        whenever(trainSessionService.getAllHordes()).thenReturn(hordes)
+
+        val response = controller.getHordes(principal)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(1, response.body?.size)
+        assertEquals("Horde 1", response.body?.first()?.name)
+        verify(trainSessionService).getAllHordes()
     }
 
     // ─── Helpers ──────────────────────────────────────────────────────────────

--- a/src/test/kotlin/br/inatel/tcc/controller/UserControllerTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/controller/UserControllerTest.kt
@@ -34,8 +34,8 @@ class UserControllerTest {
         email = "test@example.com",
         birthdayDate = LocalDate.of(1990, 1, 1),
         maxHeartRate = 180,
-        height = 175.0,
-        weight = 70.0
+        height = 175.99,
+        weight = 70.56
     )
 
     // ─── GET /users/{id} ──────────────────────────────────────────────────────

--- a/src/test/kotlin/br/inatel/tcc/dto/UserResponseDtoTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/dto/UserResponseDtoTest.kt
@@ -1,0 +1,41 @@
+package br.inatel.tcc.dto
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+class UserResponseDtoTest {
+
+    @Test
+    fun shouldRoundHeightAndWeightToTwoDecimalPlaces() {
+        val dto = UserResponseDto(
+            id = UUID.randomUUID(),
+            email = "user@example.com",
+            name = "Test User",
+            birthdayDate = LocalDate.now(),
+            maxHeartRate = 190,
+            height = 1.7583,
+            weight = 70.1234
+        )
+
+        assertEquals(1.76, dto.height)
+        assertEquals(70.12, dto.weight)
+    }
+
+    @Test
+    fun shouldHandleNullHeightAndWeight() {
+        val dto = UserResponseDto(
+            id = UUID.randomUUID(),
+            email = "user@example.com",
+            name = "Test User",
+            birthdayDate = LocalDate.now(),
+            maxHeartRate = 190,
+            height = null,
+            weight = null
+        )
+
+        assertEquals(null, dto.height)
+        assertEquals(null, dto.weight)
+    }
+}

--- a/src/test/kotlin/br/inatel/tcc/service/AchievementServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/AchievementServiceTest.kt
@@ -1,0 +1,180 @@
+package br.inatel.tcc.service
+
+import br.inatel.tcc.domain.achievement.Achievement
+import br.inatel.tcc.domain.achievement.AchievementRepository
+import br.inatel.tcc.domain.horde.Horde
+import br.inatel.tcc.domain.horde.HordeDifficulty
+import br.inatel.tcc.domain.trainsession.TrainSession
+import br.inatel.tcc.domain.trainsession.TrainSessionRepository
+import br.inatel.tcc.domain.user.User
+import br.inatel.tcc.domain.userachievement.UserAchievement
+import br.inatel.tcc.domain.userachievement.UserAchievementRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.DefaultTypedTuple
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class AchievementServiceTest {
+
+    @Mock private lateinit var achievementRepository: AchievementRepository
+    @Mock private lateinit var userAchievementRepository: UserAchievementRepository
+    @Mock private lateinit var trainSessionRepository: TrainSessionRepository
+
+    @InjectMocks private lateinit var service: AchievementService
+
+    private val userId = UUID.randomUUID()
+    private val user = User(id = userId, email = "test@test.com", name = "Test", password = "enc")
+
+    private fun buildAchievement(criterion: String) = Achievement(
+        id = UUID.randomUUID(), title = "Achievement $criterion", criterion = criterion
+    )
+
+    private fun buildSession(horde: Horde? = null) = TrainSession(
+        id = UUID.randomUUID(), user = user, horde = horde
+    )
+
+    private fun buildHorde() = Horde(
+        id = UUID.randomUUID(), name = "Horda", difficulty = HordeDifficulty.MEDIUM, estimatedDuration = 30
+    )
+
+    // ─── FIRST_RUN ────────────────────────────────────────────────────────────
+
+    @Test
+    fun shouldGrantFirstRun_whenFirstCompletedSession() {
+        val achievement = buildAchievement("FIRST_RUN")
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+        whenever(trainSessionRepository.countByUser_IdAndEndDateIsNotNull(userId)).thenReturn(1L)
+        whenever(userAchievementRepository.save(any<UserAchievement>())).thenAnswer { it.arguments[0] }
+
+        service.verifyAndGrant(user, buildSession(), emptySet())
+
+        verify(userAchievementRepository).save(any<UserAchievement>())
+    }
+
+    @Test
+    fun shouldNotGrantFirstRun_whenMultipleSessionsCompleted() {
+        val achievement = buildAchievement("FIRST_RUN")
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+        whenever(trainSessionRepository.countByUser_IdAndEndDateIsNotNull(userId)).thenReturn(3L)
+
+        service.verifyAndGrant(user, buildSession(), emptySet())
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    // ─── DISTANCE_5KM ─────────────────────────────────────────────────────────
+
+    @Test
+    fun shouldGrantDistance5km_whenUserRanFiveOrMoreKm() {
+        val achievement = buildAchievement("DISTANCE_5KM")
+        val leaderboard = linkedSetOf(DefaultTypedTuple(userId.toString(), 5.0))
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+        whenever(userAchievementRepository.save(any<UserAchievement>())).thenAnswer { it.arguments[0] }
+
+        service.verifyAndGrant(user, buildSession(), leaderboard)
+
+        verify(userAchievementRepository).save(any<UserAchievement>())
+    }
+
+    @Test
+    fun shouldNotGrantDistance5km_whenUserRanLessThanFiveKm() {
+        val achievement = buildAchievement("DISTANCE_5KM")
+        val leaderboard = linkedSetOf(DefaultTypedTuple(userId.toString(), 4.9))
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+
+        service.verifyAndGrant(user, buildSession(), leaderboard)
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    // ─── HORDE_TOP_1 ──────────────────────────────────────────────────────────
+
+    @Test
+    fun shouldGrantHordeTop1_whenUserFinishedFirstWithHorde() {
+        val achievement = buildAchievement("HORDE_TOP_1")
+        val leaderboard = linkedSetOf(
+            DefaultTypedTuple(userId.toString(), 5.0),
+            DefaultTypedTuple(UUID.randomUUID().toString(), 3.0)
+        )
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+        whenever(userAchievementRepository.save(any<UserAchievement>())).thenAnswer { it.arguments[0] }
+
+        service.verifyAndGrant(user, buildSession(horde = buildHorde()), leaderboard)
+
+        verify(userAchievementRepository).save(any<UserAchievement>())
+    }
+
+    @Test
+    fun shouldNotGrantHordeTop1_whenSessionHasNoHorde() {
+        val achievement = buildAchievement("HORDE_TOP_1")
+        val leaderboard = linkedSetOf(DefaultTypedTuple(userId.toString(), 5.0))
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+
+        service.verifyAndGrant(user, buildSession(horde = null), leaderboard)
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    @Test
+    fun shouldNotGrantHordeTop1_whenUserIsNotFirst() {
+        val achievement = buildAchievement("HORDE_TOP_1")
+        val otherId = UUID.randomUUID()
+        val leaderboard = linkedSetOf(
+            DefaultTypedTuple(otherId.toString(), 6.0),
+            DefaultTypedTuple(userId.toString(), 5.0)
+        )
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+
+        service.verifyAndGrant(user, buildSession(horde = buildHorde()), leaderboard)
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    // ─── Casos gerais ─────────────────────────────────────────────────────────
+
+    @Test
+    fun shouldNotGrant_whenAchievementAlreadyConceded() {
+        val achievement = buildAchievement("FIRST_RUN")
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(true)
+
+        service.verifyAndGrant(user, buildSession(), emptySet())
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    @Test
+    fun shouldDoNothing_whenNoActiveAchievements() {
+        whenever(achievementRepository.findByActive(true)).thenReturn(emptyList())
+
+        service.verifyAndGrant(user, buildSession(), emptySet())
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+
+    @Test
+    fun shouldIgnoreUnknownCriterion() {
+        val achievement = buildAchievement("UNKNOWN_CRITERION")
+        whenever(achievementRepository.findByActive(true)).thenReturn(listOf(achievement))
+        whenever(userAchievementRepository.existsByIdUserIdAndIdAchievementId(userId, achievement.id!!)).thenReturn(false)
+
+        service.verifyAndGrant(user, buildSession(), emptySet())
+
+        verify(userAchievementRepository, never()).save(any())
+    }
+}

--- a/src/test/kotlin/br/inatel/tcc/service/BiometricPersistenceServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/BiometricPersistenceServiceTest.kt
@@ -1,0 +1,80 @@
+package br.inatel.tcc.service
+
+import br.inatel.tcc.domain.biometricdata.BiometricData
+import br.inatel.tcc.domain.biometricdata.BiometricDataRepository
+import br.inatel.tcc.domain.trainsession.TrainSession
+import br.inatel.tcc.domain.trainsession.TrainSessionRepository
+import br.inatel.tcc.domain.user.User
+import br.inatel.tcc.dto.BiometricDataMessage
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class BiometricPersistenceServiceTest {
+
+    @Mock private lateinit var biometricDataRepository: BiometricDataRepository
+    @Mock private lateinit var trainSessionRepository: TrainSessionRepository
+
+    @InjectMocks private lateinit var service: BiometricPersistenceService
+
+    private val sessionId = UUID.randomUUID()
+    private val userId = UUID.randomUUID()
+
+    private fun buildMessage(sid: String = sessionId.toString()) = BiometricDataMessage(
+        sessionId = sid,
+        userId = userId.toString(),
+        timestamp = System.currentTimeMillis(),
+        bpm = 155,
+        cadence = 80.0,
+        speed = 10.0,
+        pace = 6.0,
+        accumulatedDistance = 2.5,
+        accumulatedCalories = 120.0
+    )
+
+    private fun buildSession() = TrainSession(
+        id = sessionId,
+        user = User(id = userId, email = "test@test.com", name = "Test", password = "enc")
+    )
+
+    @Test
+    fun shouldSaveBiometricData_whenSessionExists() {
+        val message = buildMessage()
+        val session = buildSession()
+        whenever(trainSessionRepository.findById(sessionId)).thenReturn(Optional.of(session))
+        whenever(biometricDataRepository.save(any<BiometricData>())).thenAnswer { it.arguments[0] }
+
+        service.persistAsync(message)
+
+        verify(biometricDataRepository).save(any<BiometricData>())
+    }
+
+    @Test
+    fun shouldNotSave_whenSessionNotFound() {
+        val message = buildMessage()
+        whenever(trainSessionRepository.findById(sessionId)).thenReturn(Optional.empty())
+
+        service.persistAsync(message)
+
+        verify(biometricDataRepository, never()).save(any())
+    }
+
+    @Test
+    fun shouldNotSave_whenSessionIdIsInvalidUUID() {
+        val message = buildMessage(sid = "not-a-uuid")
+
+        service.persistAsync(message)
+
+        verify(trainSessionRepository, never()).findById(any())
+        verify(biometricDataRepository, never()).save(any())
+    }
+}

--- a/src/test/kotlin/br/inatel/tcc/service/CardiacZoneServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/CardiacZoneServiceTest.kt
@@ -1,0 +1,105 @@
+package br.inatel.tcc.service
+
+import br.inatel.tcc.domain.biometricdata.CardiacZone
+import br.inatel.tcc.domain.user.User
+import br.inatel.tcc.domain.user.UserRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Duration
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.util.Optional
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+class CardiacZoneServiceTest {
+
+    @Mock private lateinit var userRepository: UserRepository
+    @Mock private lateinit var redis: StringRedisTemplate
+    @Mock private lateinit var valueOps: ValueOperations<String, String>
+
+    @InjectMocks private lateinit var service: CardiacZoneService
+
+    private val sessionId = "session-abc"
+    private val userId = UUID.randomUUID()
+    private val maxHrKey = "session:$sessionId:user:$userId:maxhr"
+
+    // ─── calculate ────────────────────────────────────────────────────────────
+
+    @Test fun shouldReturnZone1_whenBpmBelow60Pct() = assertEquals(CardiacZone.ZONE_1, service.calculate(100, 200))
+    @Test fun shouldReturnZone2_whenBpmBetween60And70Pct() = assertEquals(CardiacZone.ZONE_2, service.calculate(130, 200))
+    @Test fun shouldReturnZone3_whenBpmBetween70And80Pct() = assertEquals(CardiacZone.ZONE_3, service.calculate(150, 200))
+    @Test fun shouldReturnZone4_whenBpmBetween80And90Pct() = assertEquals(CardiacZone.ZONE_4, service.calculate(170, 200))
+    @Test fun shouldReturnZone5_whenBpmAt90PctOrAbove() = assertEquals(CardiacZone.ZONE_5, service.calculate(185, 200))
+
+    // ─── getOrCacheMaxHr ──────────────────────────────────────────────────────
+
+    @Test
+    fun shouldReturnCachedMaxHr_whenPresentInRedis() {
+        whenever(redis.opsForValue()).thenReturn(valueOps)
+        whenever(valueOps.get(maxHrKey)).thenReturn("180")
+
+        val result = service.getOrCacheMaxHr(sessionId, userId.toString())
+
+        assertEquals(180, result)
+        verify(userRepository, never()).findById(any())
+    }
+
+    @Test
+    fun shouldQueryDbAndCache_whenNotInRedis() {
+        val user = User(id = userId, email = "a@b.com", name = "A", password = "p", maxHeartRate = 190)
+        whenever(redis.opsForValue()).thenReturn(valueOps)
+        whenever(valueOps.get(maxHrKey)).thenReturn(null)
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(user))
+
+        val result = service.getOrCacheMaxHr(sessionId, userId.toString())
+
+        assertEquals(190, result)
+        verify(valueOps).set(eq(maxHrKey), eq("190"), any<Duration>())
+    }
+
+    @Test
+    fun shouldReturnNull_whenUserHasNoMaxHeartRate() {
+        val user = User(id = userId, email = "a@b.com", name = "A", password = "p", maxHeartRate = null)
+        whenever(redis.opsForValue()).thenReturn(valueOps)
+        whenever(valueOps.get(maxHrKey)).thenReturn(null)
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(user))
+
+        val result = service.getOrCacheMaxHr(sessionId, userId.toString())
+
+        assertNull(result)
+        verify(valueOps, never()).set(any<String>(), any<String>(), any<Duration>())
+    }
+
+    @Test
+    fun shouldReturnNull_whenUserNotFound() {
+        whenever(redis.opsForValue()).thenReturn(valueOps)
+        whenever(valueOps.get(maxHrKey)).thenReturn(null)
+        whenever(userRepository.findById(userId)).thenReturn(Optional.empty())
+
+        val result = service.getOrCacheMaxHr(sessionId, userId.toString())
+
+        assertNull(result)
+    }
+
+    @Test
+    fun shouldReturnNull_whenUserIdIsInvalidUUID() {
+        whenever(redis.opsForValue()).thenReturn(valueOps)
+        whenever(valueOps.get(any())).thenReturn(null)
+
+        val result = service.getOrCacheMaxHr(sessionId, "not-a-uuid")
+
+        assertNull(result)
+        verify(userRepository, never()).findById(any())
+    }
+}

--- a/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
@@ -11,6 +11,7 @@ import br.inatel.tcc.domain.user.User
 import br.inatel.tcc.domain.user.UserRepository
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.service.redis.LeaderboardRedisService
+import br.inatel.tcc.service.AchievementService
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -36,6 +37,7 @@ class TrainSessionServiceTest {
     @Mock private lateinit var rankingRepository: RankingRepository
     @Mock private lateinit var leaderboardRedisService: LeaderboardRedisService
     @Mock private lateinit var hordePositionService: HordePositionService
+    @Mock private lateinit var achievementService: AchievementService
 
     @InjectMocks private lateinit var service: TrainSessionService
 

--- a/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
@@ -11,6 +11,7 @@ import br.inatel.tcc.domain.user.User
 import br.inatel.tcc.domain.user.UserRepository
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.service.redis.LeaderboardRedisService
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -173,4 +174,26 @@ class TrainSessionServiceTest {
 
         verify(leaderboardRedisService).expireSessionKeys(sessionId.toString())
     }
+
+    // ─── getAllHordes ─────────────────────────────────────────────────────────
+
+    @Test
+    fun shouldReturnAllHordes() {
+        val hordeId1 = UUID.randomUUID()
+        val hordeId2 = UUID.randomUUID()
+        val hordes = listOf(
+            Horde(id = hordeId1, name = "Easy Horde", difficulty = HordeDifficulty.EASY, estimatedDuration = 30),
+            Horde(id = hordeId2, name = "Hard Horde", difficulty = HordeDifficulty.HARD, estimatedDuration = 90)
+        )
+        whenever(hordeRepository.findAll()).thenReturn(hordes)
+
+        val result = service.getAllHordes()
+
+        assertEquals(2, result.size)
+        assertEquals("Easy Horde", result[0].name)
+        assertEquals(HordeDifficulty.EASY, result[0].difficulty)
+        assertEquals("Hard Horde", result[1].name)
+        assertEquals(HordeDifficulty.HARD, result[1].difficulty)
+    }
 }
+

--- a/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
@@ -9,6 +9,9 @@ import br.inatel.tcc.domain.trainsession.TrainSessionRepository
 import br.inatel.tcc.domain.trainsession.TrainType
 import br.inatel.tcc.domain.user.User
 import br.inatel.tcc.domain.user.UserRepository
+import br.inatel.tcc.domain.friendship.Friendship
+import br.inatel.tcc.domain.friendship.FriendshipRepository
+import br.inatel.tcc.domain.friendship.FriendshipStatus
 import br.inatel.tcc.dto.StartSessionRequest
 import br.inatel.tcc.service.redis.LeaderboardRedisService
 import br.inatel.tcc.service.AchievementService
@@ -22,10 +25,12 @@ import org.mockito.Mock
 import org.mockito.Mockito.times
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.data.redis.core.DefaultTypedTuple
+import org.springframework.messaging.simp.SimpMessagingTemplate
 import java.util.Optional
 import java.util.UUID
 
@@ -39,6 +44,8 @@ class TrainSessionServiceTest {
     @Mock private lateinit var leaderboardRedisService: LeaderboardRedisService
     @Mock private lateinit var hordePositionService: HordePositionService
     @Mock private lateinit var achievementService: AchievementService
+    @Mock private lateinit var friendshipRepository: FriendshipRepository
+    @Mock private lateinit var messagingTemplate: SimpMessagingTemplate
 
     @InjectMocks private lateinit var service: TrainSessionService
 
@@ -194,6 +201,48 @@ class TrainSessionServiceTest {
         service.endSession(sessionId.toString())
 
         verify(leaderboardRedisService).expireSessionKeys(sessionId.toString())
+    }
+
+    // ─── notifyFriends ────────────────────────────────────────────────────────
+
+    @Test
+    fun shouldNotifyAcceptedFriends_onSessionEnd() {
+        val friendId = UUID.randomUUID()
+        val friend = User(id = friendId, email = "friend@test.com", name = "Friend", password = "enc")
+        val sess = buildSession()
+        val friendship = Friendship(
+            requester = buildUser(),
+            recipient = friend,
+            status = FriendshipStatus.ACCEPTED
+        )
+        val leaderboard = linkedSetOf(DefaultTypedTuple(userId.toString(), 5.0))
+
+        whenever(trainSessionRepository.findById(sessionId)).thenReturn(Optional.of(sess))
+        whenever(leaderboardRedisService.getFullLeaderboard(sessionId.toString())).thenReturn(leaderboard)
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(buildUser()))
+        whenever(rankingRepository.save(any())).thenAnswer { it.arguments[0] }
+        whenever(trainSessionRepository.save(any())).thenAnswer { it.arguments[0] }
+        whenever(friendshipRepository.findByRequesterIdOrRecipientId(userId, userId)).thenReturn(listOf(friendship))
+
+        service.endSession(sessionId.toString())
+
+        verify(messagingTemplate).convertAndSend(
+            eq("/topic/user/$friendId/notifications"),
+            any<br.inatel.tcc.dto.SessionResultNotification>()
+        )
+    }
+
+    @Test
+    fun shouldNotNotify_whenUserHasNoAcceptedFriends() {
+        val sess = buildSession()
+        whenever(trainSessionRepository.findById(sessionId)).thenReturn(Optional.of(sess))
+        whenever(leaderboardRedisService.getFullLeaderboard(sessionId.toString())).thenReturn(emptySet())
+        whenever(trainSessionRepository.save(any())).thenAnswer { it.arguments[0] }
+        whenever(friendshipRepository.findByRequesterIdOrRecipientId(userId, userId)).thenReturn(emptyList())
+
+        service.endSession(sessionId.toString())
+
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<Any>())
     }
 
     // ─── getAllHordes ─────────────────────────────────────────────────────────

--- a/src/test/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisServiceTest.kt
@@ -152,12 +152,13 @@ class LeaderboardRedisServiceTest {
     // ─── expireSessionKeys ────────────────────────────────────────────────────
 
     @Test
-    fun shouldExpireAllThreeKeys() {
+    fun shouldExpireAllKeys() {
         service.expireSessionKeys(sessionId)
 
-        verify(redis, times(3)).expire(any(), eq(Duration.ofHours(1)))
+        verify(redis, times(4)).expire(any(), eq(Duration.ofHours(1)))
         verify(redis).expire(leaderboardKey, Duration.ofHours(1))
         verify(redis).expire(startKey, Duration.ofHours(1))
         verify(redis).expire(hordeKey, Duration.ofHours(1))
+        verify(redis).expire("session:$sessionId:horde:adaptive", Duration.ofHours(1))
     }
 }


### PR DESCRIPTION
**1. Zona Cardíaca**
- CardiacZoneService (novo): calculate(bpm, maxHr) mapeia % do FC máximo para ZONE_1–5; getOrCacheMaxHr() busca o maxHeartRate do usuário no Redis (hit) ou no PostgreSQL (miss → cacheia com TTL 24h)
- SessionRedisService.saveUserState(): recebe cardiacZone: CardiacZone? = null e armazena no HASH; novo getCardiacZones() lê o campo de múltiplos usuários
- LeaderboardEntryDto: novo campo cardiacZone: CardiacZone?
- BiometricWebSocketController: calcula zona do usuário atual e a de cada competidor no top-10 via Redis, inclui no response

**2. Campos Horda no Response**
- LeaderboardResponse: novos campos isBehindHorde: Boolean? e distanceToHorde: Double? (negativo = usuário à frente)
- Calculados no controller: hordeVirtualDistanceKm?.let { message.accumulatedDistance < it }

**3. Notificação de Amigos**
- SessionResultNotification (novo DTO): type, userId, userName, sessionId, totalDistanceKm, rank
- TrainSessionService: injeta FriendshipRepository e SimpMessagingTemplate; método notifyFriends() busca amizades ACCEPTED, determina rank do usuário e envia notificação para /topic/user/{friendId}/notifications de cada amigo


