### PR TITLE
feat: Implement GameStateResponse DTO and real-time game state updates

### DIFF
--- a/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
@@ -141,7 +141,7 @@ class BiometricWebSocketController(
             raceProgress = raceProgress,
             gameStatus = gameStatus
         )
-        messagingTemplate.convertAndSend("/topic/session/${message.sessionId}/user/${message.userId}/game-state", gameStateResponse)
+        messagingTemplate.convertAndSend("/topic/session/${message.sessionId}/game-state", gameStateResponse)
 
         val elapsed = System.currentTimeMillis() - start
         log.info(

--- a/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
+++ b/src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt
@@ -3,6 +3,8 @@ package br.inatel.tcc.controller
 import br.inatel.tcc.dto.BiometricDataMessage
 import br.inatel.tcc.dto.LeaderboardEntryDto
 import br.inatel.tcc.dto.LeaderboardResponse
+import br.inatel.tcc.dto.GameStateResponse
+import br.inatel.tcc.dto.GameStatus
 import br.inatel.tcc.service.BiometricPersistenceService
 import br.inatel.tcc.service.CardiacZoneService
 import br.inatel.tcc.service.HordePositionService
@@ -109,6 +111,37 @@ class BiometricWebSocketController(
             distanceToHorde = distanceToHorde
         )
         messagingTemplate.convertAndSend("/topic/session/${message.sessionId}/leaderboard", response)
+
+        val goalDistance = leaderboardRedisService.getGoalDistance(message.sessionId) ?: 0.0
+        val hordePosition = hordeVirtualDistance ?: 0.0
+        val playerPosition = message.accumulatedDistance
+        val distanceToGoal = if (goalDistance > 0.0) kotlin.math.max(0.0, goalDistance - playerPosition) else 0.0
+        val distancePlayerToHorde = kotlin.math.abs(playerPosition - hordePosition)
+        val playerSpeed = message.speed
+        val hordeSpeed = if (hordePace != null && hordePace > 0.0) 60.0 / hordePace else 0.0
+        val raceProgress = if (goalDistance > 0.0) kotlin.math.min(100.0, (playerPosition / goalDistance) * 100.0) else 0.0
+
+        val gameStatus = if (hordeVirtualDistance != null && hordeVirtualDistance >= playerPosition) {
+            GameStatus.CAUGHT
+        } else if (goalDistance > 0.0 && playerPosition >= goalDistance) {
+            GameStatus.ESCAPED
+        } else {
+            GameStatus.RUNNING
+        }
+
+        val gameStateResponse = GameStateResponse(
+            sessionId = message.sessionId,
+            userId = message.userId,
+            playerPosition = playerPosition,
+            hordePosition = hordePosition,
+            distanceToGoal = distanceToGoal,
+            distancePlayerToHorde = distancePlayerToHorde,
+            playerSpeed = playerSpeed,
+            hordeSpeed = hordeSpeed,
+            raceProgress = raceProgress,
+            gameStatus = gameStatus
+        )
+        messagingTemplate.convertAndSend("/topic/session/${message.sessionId}/user/${message.userId}/game-state", gameStateResponse)
 
         val elapsed = System.currentTimeMillis() - start
         log.info(

--- a/src/main/kotlin/br/inatel/tcc/dto/GameStateResponse.kt
+++ b/src/main/kotlin/br/inatel/tcc/dto/GameStateResponse.kt
@@ -7,6 +7,8 @@ enum class GameStatus {
 }
 
 data class GameStateResponse(
+    val sessionId: String,
+    val userId: String,
     val playerPosition: Double,
     val hordePosition: Double,
     val distanceToGoal: Double,

--- a/src/main/kotlin/br/inatel/tcc/dto/GameStateResponse.kt
+++ b/src/main/kotlin/br/inatel/tcc/dto/GameStateResponse.kt
@@ -1,0 +1,18 @@
+package br.inatel.tcc.dto
+
+enum class GameStatus {
+    RUNNING,
+    CAUGHT,
+    ESCAPED
+}
+
+data class GameStateResponse(
+    val playerPosition: Double,
+    val hordePosition: Double,
+    val distanceToGoal: Double,
+    val distancePlayerToHorde: Double,
+    val playerSpeed: Double,
+    val hordeSpeed: Double,
+    val raceProgress: Double,
+    val gameStatus: GameStatus
+)

--- a/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt
@@ -79,7 +79,8 @@ class TrainSessionService(
         leaderboardRedisService.initSession(
             sessionId,
             horde?.let { hordePositionService.resolveEffectivePace(it) },
-            horde?.isAdaptive ?: false
+            horde?.isAdaptive ?: false,
+            horde?.estimatedDuration
         )
 
         return StartSessionResponse(sessionId = sessionId)

--- a/src/main/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisService.kt
+++ b/src/main/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisService.kt
@@ -32,20 +32,19 @@ class LeaderboardRedisService(
     private fun startKey(sessionId: String) = "session:$sessionId:start"
     private fun hordeKey(sessionId: String) = "session:$sessionId:horde:pace"
     private fun hordeAdaptiveKey(sessionId: String) = "session:$sessionId:horde:adaptive"
+    private fun goalDistanceKey(sessionId: String) = "session:$sessionId:goal:distance"
 
-    /**
-     * Inicializa os metadados da sessão no Redis.
-     * Chamado uma vez no POST /sessions/iniciar, logo após criar o TrainSession no PostgreSQL.
-     *
-     * Usa verificação de existência para ser idempotente — reconexões não sobrescrevem o start.
-     */
-    fun initSession(sessionId: String, targetPaceMinPerKm: Double?, isAdaptive: Boolean = false) {
+    fun initSession(
+        sessionId: String,
+        targetPaceMinPerKm: Double?,
+        isAdaptive: Boolean = false,
+        estimatedDurationMin: Int? = null
+    ) {
         val startKey = startKey(sessionId)
         if (redis.hasKey(startKey) != true) {
             val epochSeconds = System.currentTimeMillis() / 1000
             redis.opsForValue().set(startKey, epochSeconds.toString(), Duration.ofHours(24))
 
-            // Armazena o pace da Horda para evitar busca no PostgreSQL a cada update de biometria
             targetPaceMinPerKm?.let {
                 redis.opsForValue().set(hordeKey(sessionId), it.toString(), Duration.ofHours(24))
             }
@@ -53,43 +52,37 @@ class LeaderboardRedisService(
             if (isAdaptive) {
                 redis.opsForValue().set(hordeAdaptiveKey(sessionId), "true", Duration.ofHours(24))
             }
+
+            if (targetPaceMinPerKm != null && targetPaceMinPerKm > 0 && estimatedDurationMin != null) {
+                val goalDistance = estimatedDurationMin.toDouble() / targetPaceMinPerKm
+                redis.opsForValue().set(goalDistanceKey(sessionId), goalDistance.toString(), Duration.ofHours(24))
+            }
         }
     }
 
-    /** Retorna true se a horda desta sessão está em modo adaptativo. */
+    fun getGoalDistance(sessionId: String): Double? {
+        return redis.opsForValue().get(goalDistanceKey(sessionId))?.toDouble()
+    }
+
     fun isHordeAdaptive(sessionId: String): Boolean =
         redis.opsForValue().get(hordeAdaptiveKey(sessionId)) == "true"
 
-    /**
-     * Atualiza o pace da horda no Redis.
-     * Usado pelo modo adaptativo para refletir a performance média atual dos usuários.
-     */
     fun updateHordePace(sessionId: String, pace: Double) {
         redis.opsForValue().set(hordeKey(sessionId), pace.toString(), Duration.ofHours(24))
     }
 
-    /**
-     * Atualiza a distância do usuário no leaderboard.
-     * ZADD sobrescreve o score anterior — sempre reflete a posição atual, não acumulada dupla.
-     */
     fun updateUserDistance(sessionId: String, userId: String, distanceKm: Double) {
         redis.opsForZSet().add(leaderboardKey(sessionId), userId, distanceKm)
     }
 
-    /**
-     * Retorna o rank 0-based do usuário (0 = primeiro lugar).
-     * ZREVRANK: ordena do maior score (maior distância) para o menor.
-     */
     fun getUserRank(sessionId: String, userId: String): Long? {
         return redis.opsForZSet().reverseRank(leaderboardKey(sessionId), userId)
     }
 
-    /** Retorna os top-N usuários com seus scores (ZREVRANGE WITHSCORES). */
     fun getTopEntries(sessionId: String, count: Long = 10): Set<ZSetOperations.TypedTuple<String>>? {
         return redis.opsForZSet().reverseRangeWithScores(leaderboardKey(sessionId), 0, count - 1)
     }
 
-    /** Retorna o leaderboard completo — usado no flush final para o PostgreSQL. */
     fun getFullLeaderboard(sessionId: String): Set<ZSetOperations.TypedTuple<String>>? {
         return redis.opsForZSet().reverseRangeWithScores(leaderboardKey(sessionId), 0, -1)
     }
@@ -102,15 +95,12 @@ class LeaderboardRedisService(
         return redis.opsForValue().get(hordeKey(sessionId))?.toDouble()
     }
 
-    /**
-     * Reduz o TTL dos keys da sessão para 1h após encerramento.
-     * Mantém dados disponíveis brevemente para consultas pós-corrida, sem ocupar memória indefinidamente.
-     */
     fun expireSessionKeys(sessionId: String) {
         val ttl = Duration.ofHours(1)
         redis.expire(leaderboardKey(sessionId), ttl)
         redis.expire(startKey(sessionId), ttl)
         redis.expire(hordeKey(sessionId), ttl)
         redis.expire(hordeAdaptiveKey(sessionId), ttl)
+        redis.expire(goalDistanceKey(sessionId), ttl)
     }
 }

--- a/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
@@ -241,7 +241,7 @@ class BiometricWebSocketControllerTest {
         controller.receiveBiometricData(message)
 
         verify(messagingTemplate).convertAndSend(
-            eq("/topic/session/$sessionId/user/$userId/game-state"),
+            eq("/topic/session/$sessionId/game-state"),
             captor.capture()
         )
         val state = captor.firstValue
@@ -268,7 +268,7 @@ class BiometricWebSocketControllerTest {
         controller.receiveBiometricData(message)
 
         verify(messagingTemplate).convertAndSend(
-            eq("/topic/session/$sessionId/user/$userId/game-state"),
+            eq("/topic/session/$sessionId/game-state"),
             captor.capture()
         )
         val state = captor.firstValue
@@ -288,7 +288,7 @@ class BiometricWebSocketControllerTest {
         controller.receiveBiometricData(message)
 
         verify(messagingTemplate).convertAndSend(
-            eq("/topic/session/$sessionId/user/$userId/game-state"),
+            eq("/topic/session/$sessionId/game-state"),
             captor.capture()
         )
         val state = captor.firstValue

--- a/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt
@@ -24,6 +24,8 @@ import org.mockito.kotlin.whenever
 import org.springframework.data.redis.core.DefaultTypedTuple
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import br.inatel.tcc.dto.LeaderboardResponse
+import br.inatel.tcc.dto.GameStateResponse
+import br.inatel.tcc.dto.GameStatus
 
 @ExtendWith(MockitoExtension::class)
 class BiometricWebSocketControllerTest {
@@ -37,6 +39,11 @@ class BiometricWebSocketControllerTest {
     @Mock private lateinit var cardiacZoneService: CardiacZoneService
 
     @InjectMocks private lateinit var controller: BiometricWebSocketController
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() {
+        org.mockito.Mockito.lenient().`when`(leaderboardRedisService.getGoalDistance(any())).thenReturn(null)
+    }
 
     private val sessionId = "session-abc"
     private val userId = "user-123"
@@ -219,6 +226,73 @@ class BiometricWebSocketControllerTest {
         controller.receiveBiometricData(message)
 
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<LeaderboardResponse>())
+    }
+
+    @Test
+    fun shouldBroadcastGameStateWithCorrectDetails() {
+        val message = buildMessage(distance = 2.0)
+        setupLeaderboardMocks(rank = 0L)
+        whenever(leaderboardRedisService.getGoalDistance(sessionId)).thenReturn(10.0)
+        whenever(leaderboardRedisService.getSessionStartEpoch(sessionId)).thenReturn(1000L)
+        whenever(leaderboardRedisService.getHordePace(sessionId)).thenReturn(6.0)
+        whenever(hordePositionService.calculateVirtualPosition(any(), any())).thenReturn(1.0)
+
+        val captor = argumentCaptor<GameStateResponse>()
+        controller.receiveBiometricData(message)
+
+        verify(messagingTemplate).convertAndSend(
+            eq("/topic/session/$sessionId/user/$userId/game-state"),
+            captor.capture()
+        )
+        val state = captor.firstValue
+        org.junit.jupiter.api.Assertions.assertEquals(2.0, state.playerPosition)
+        org.junit.jupiter.api.Assertions.assertEquals(1.0, state.hordePosition)
+        org.junit.jupiter.api.Assertions.assertEquals(8.0, state.distanceToGoal)
+        org.junit.jupiter.api.Assertions.assertEquals(1.0, state.distancePlayerToHorde)
+        org.junit.jupiter.api.Assertions.assertEquals(10.0, state.playerSpeed)
+        org.junit.jupiter.api.Assertions.assertEquals(10.0, state.hordeSpeed)
+        org.junit.jupiter.api.Assertions.assertEquals(20.0, state.raceProgress)
+        org.junit.jupiter.api.Assertions.assertEquals(GameStatus.RUNNING, state.gameStatus)
+    }
+
+    @Test
+    fun shouldBroadcastGameStateWhenCaught() {
+        val message = buildMessage(distance = 1.0)
+        setupLeaderboardMocks(rank = 0L)
+        whenever(leaderboardRedisService.getGoalDistance(sessionId)).thenReturn(10.0)
+        whenever(leaderboardRedisService.getSessionStartEpoch(sessionId)).thenReturn(1000L)
+        whenever(leaderboardRedisService.getHordePace(sessionId)).thenReturn(6.0)
+        whenever(hordePositionService.calculateVirtualPosition(any(), any())).thenReturn(1.5)
+
+        val captor = argumentCaptor<GameStateResponse>()
+        controller.receiveBiometricData(message)
+
+        verify(messagingTemplate).convertAndSend(
+            eq("/topic/session/$sessionId/user/$userId/game-state"),
+            captor.capture()
+        )
+        val state = captor.firstValue
+        org.junit.jupiter.api.Assertions.assertEquals(GameStatus.CAUGHT, state.gameStatus)
+    }
+
+    @Test
+    fun shouldBroadcastGameStateWhenEscaped() {
+        val message = buildMessage(distance = 10.5)
+        setupLeaderboardMocks(rank = 0L)
+        whenever(leaderboardRedisService.getGoalDistance(sessionId)).thenReturn(10.0)
+        whenever(leaderboardRedisService.getSessionStartEpoch(sessionId)).thenReturn(1000L)
+        whenever(leaderboardRedisService.getHordePace(sessionId)).thenReturn(6.0)
+        whenever(hordePositionService.calculateVirtualPosition(any(), any())).thenReturn(5.0)
+
+        val captor = argumentCaptor<GameStateResponse>()
+        controller.receiveBiometricData(message)
+
+        verify(messagingTemplate).convertAndSend(
+            eq("/topic/session/$sessionId/user/$userId/game-state"),
+            captor.capture()
+        )
+        val state = captor.firstValue
+        org.junit.jupiter.api.Assertions.assertEquals(GameStatus.ESCAPED, state.gameStatus)
     }
 
     // ─── Helpers ──────────────────────────────────────────────────────────────

--- a/src/test/kotlin/br/inatel/tcc/dto/GameStateResponseTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/dto/GameStateResponseTest.kt
@@ -1,0 +1,30 @@
+package br.inatel.tcc.dto
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GameStateResponseTest {
+
+    @Test
+    fun shouldCreateGameStateResponseWithCorrectValues() {
+        val response = GameStateResponse(
+            playerPosition = 100.0,
+            hordePosition = 50.0,
+            distanceToGoal = 400.0,
+            distancePlayerToHorde = 50.0,
+            playerSpeed = 5.5,
+            hordeSpeed = 4.8,
+            raceProgress = 20.0,
+            gameStatus = GameStatus.RUNNING
+        )
+
+        assertEquals(100.0, response.playerPosition)
+        assertEquals(50.0, response.hordePosition)
+        assertEquals(400.0, response.distanceToGoal)
+        assertEquals(50.0, response.distancePlayerToHorde)
+        assertEquals(5.5, response.playerSpeed)
+        assertEquals(4.8, response.hordeSpeed)
+        assertEquals(20.0, response.raceProgress)
+        assertEquals(GameStatus.RUNNING, response.gameStatus)
+    }
+}

--- a/src/test/kotlin/br/inatel/tcc/dto/GameStateResponseTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/dto/GameStateResponseTest.kt
@@ -8,6 +8,8 @@ class GameStateResponseTest {
     @Test
     fun shouldCreateGameStateResponseWithCorrectValues() {
         val response = GameStateResponse(
+            sessionId = "session-abc",
+            userId = "user-123",
             playerPosition = 100.0,
             hordePosition = 50.0,
             distanceToGoal = 400.0,
@@ -18,6 +20,8 @@ class GameStateResponseTest {
             gameStatus = GameStatus.RUNNING
         )
 
+        assertEquals("session-abc", response.sessionId)
+        assertEquals("user-123", response.userId)
         assertEquals(100.0, response.playerPosition)
         assertEquals(50.0, response.hordePosition)
         assertEquals(400.0, response.distanceToGoal)

--- a/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt
@@ -71,9 +71,9 @@ class TrainSessionServiceTest {
         val response = service.startSession("test@example.com", StartSessionRequest(trainType = "RUN"))
 
         assertNotNull(response.sessionId)
-        verify(leaderboardRedisService).initSession(sessionId.toString(), null)
+        verify(leaderboardRedisService).initSession(sessionId.toString(), null, false, null)
     }
-
+ 
     @Test
     fun shouldStartSessionWithHorde() {
         val hordeId = UUID.randomUUID()
@@ -86,13 +86,13 @@ class TrainSessionServiceTest {
         whenever(hordeRepository.findById(hordeId)).thenReturn(Optional.of(horde))
         whenever(trainSessionRepository.save(any())).thenReturn(savedSession)
         whenever(hordePositionService.resolveEffectivePace(horde)).thenReturn(6.0)
-
+ 
         val response = service.startSession("test@example.com", StartSessionRequest(hordeId = hordeId))
-
+ 
         assertNotNull(response.sessionId)
-        verify(leaderboardRedisService).initSession(sessionId.toString(), 6.0)
+        verify(leaderboardRedisService).initSession(sessionId.toString(), 6.0, false, 60)
     }
-
+ 
     @Test
     fun shouldInheritParentPace_forSubHordeWithoutOwnPace() {
         val parentId = UUID.randomUUID()
@@ -104,10 +104,10 @@ class TrainSessionServiceTest {
         whenever(hordeRepository.findById(subHordeId)).thenReturn(Optional.of(subHorde))
         whenever(trainSessionRepository.save(any())).thenReturn(savedSession)
         whenever(hordePositionService.resolveEffectivePace(subHorde)).thenReturn(5.0)
-
+ 
         service.startSession("test@example.com", StartSessionRequest(hordeId = subHordeId))
-
-        verify(leaderboardRedisService).initSession(sessionId.toString(), 5.0)
+ 
+        verify(leaderboardRedisService).initSession(sessionId.toString(), 5.0, false, 30)
     }
 
     @Test

--- a/src/test/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisServiceTest.kt
+++ b/src/test/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisServiceTest.kt
@@ -155,10 +155,11 @@ class LeaderboardRedisServiceTest {
     fun shouldExpireAllKeys() {
         service.expireSessionKeys(sessionId)
 
-        verify(redis, times(4)).expire(any(), eq(Duration.ofHours(1)))
+        verify(redis, times(5)).expire(any(), eq(Duration.ofHours(1)))
         verify(redis).expire(leaderboardKey, Duration.ofHours(1))
         verify(redis).expire(startKey, Duration.ofHours(1))
         verify(redis).expire(hordeKey, Duration.ofHours(1))
         verify(redis).expire("session:$sessionId:horde:adaptive", Duration.ofHours(1))
+        verify(redis).expire("session:$sessionId:goal:distance", Duration.ofHours(1))
     }
 }


### PR DESCRIPTION
This pull request introduces a new real-time game state broadcast feature, including the definition and transmission of a detailed `GameStateResponse` object over WebSocket. It also enhances the session initialization logic to calculate and persist a goal distance in Redis, and updates related tests to cover these new behaviors.

**Game state broadcasting:**

* Added a new `GameStateResponse` data class and `GameStatus` enum to represent the current state of the game (running, caught, escaped), including fields for positions, speeds, distances, progress, and status. (`src/main/kotlin/br/inatel/tcc/dto/GameStateResponse.kt`)
* Updated `BiometricWebSocketController` to compute and broadcast `GameStateResponse` for each biometric data message, using values from Redis and other services. (`src/main/kotlin/br/inatel/tcc/controller/BiometricWebSocketController.kt`)

**Redis session metadata and persistence:**

* Extended `LeaderboardRedisService.initSession` to compute and store the session's goal distance in Redis based on horde pace and estimated duration. Added retrieval and expiration logic for this new key. (`src/main/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisService.kt`) [[1]](diffhunk://#diff-feeb561568eee440a69dd7a0dc789d0a87392ea70914bb16a8d9883e5f92e570R35-L92) [[2]](diffhunk://#diff-feeb561568eee440a69dd7a0dc789d0a87392ea70914bb16a8d9883e5f92e570L105-R104)
* Updated `TrainSessionService` to pass the estimated duration to `initSession`, ensuring the goal distance is set when available. (`src/main/kotlin/br/inatel/tcc/service/TrainSessionService.kt`)

**Testing enhancements:**

* Added comprehensive unit tests for the new `GameStateResponse` logic in both the controller and DTO, verifying correct values and status transitions (running, caught, escaped). (`src/test/kotlin/br/inatel/tcc/controller/BiometricWebSocketControllerTest.kt`, `src/test/kotlin/br/inatel/tcc/dto/GameStateResponseTest.kt`) [[1]](diffhunk://#diff-1d2293db399b80ae2d8635bfab77c56e27c022a0467af603886417ba5e1b9557R231-R297) [[2]](diffhunk://#diff-a4a1066a6eaf66a9e2de5a087b1a58b9ac37c8d8faa7f17e67d13cc73217caa0R1-R34)
* Updated tests for session initialization and Redis expiration to account for the new goal distance key and parameters. (`src/test/kotlin/br/inatel/tcc/service/TrainSessionServiceTest.kt`, `src/test/kotlin/br/inatel/tcc/service/redis/LeaderboardRedisServiceTest.kt`) [[1]](diffhunk://#diff-b3e883de621b246cd9360b59e80887a13878c1ea97d11b56b1844dfb45a6895cL74-R74) [[2]](diffhunk://#diff-b3e883de621b246cd9360b59e80887a13878c1ea97d11b56b1844dfb45a6895cL93-R93) [[3]](diffhunk://#diff-b3e883de621b246cd9360b59e80887a13878c1ea97d11b56b1844dfb45a6895cL110-R110) [[4]](diffhunk://#diff-a72cf4134a84ffe3ec3f27fd7676f79e0eaf61114ea2588d5396e89f97422c13L158-R163)