### PR TITLE
Fix CI shell substitution error with BRANCH_NAME

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,8 +65,8 @@ pipeline {
                         ssh -o StrictHostKeyChecking=no ${DO_USERNAME}@${DO_HOST} "
                             cd ${PROJECT_PATH} &&
                             git fetch origin &&
-                            git checkout -B ${env.BRANCH_NAME} origin/${env.BRANCH_NAME} &&
-                            git pull origin ${env.BRANCH_NAME} &&
+                            git checkout -B ${BRANCH_NAME} origin/${BRANCH_NAME} &&
+                            git pull origin ${BRANCH_NAME} &&
                             docker-compose up -d --build api postgres redis
                         "
                     '''


### PR DESCRIPTION
This pull request makes a minor update to the `Jenkinsfile` to improve environment variable usage. The change replaces references to `env.BRANCH_NAME` with `BRANCH_NAME` in the deployment script to ensure consistency and correct variable resolution.

- Deployment script now uses `BRANCH_NAME` instead of `env.BRANCH_NAME` for branch operations, which may fix issues related to environment variable scope during deployment (`Jenkinsfile`).